### PR TITLE
fix: Isolate ScrolledWindow to the check packages page

### DIFF
--- a/src/check_packages.py
+++ b/src/check_packages.py
@@ -21,6 +21,10 @@ class CheckPackages(Adw.Bin):
         header.set_decoration_layout("") # Remove window controls
         header.set_title_widget(Gtk.Label(label="Check Software"))
 
+        # Create scrollable window
+        scrolled_window = Gtk.ScrolledWindow()
+        scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+
         check_snaps_row = Adw.ExpanderRow(title="Check Snaps")
         snaps_installed = self.utils.check_snaps(snap_packages)
         for snap in snaps_installed.keys():
@@ -52,7 +56,8 @@ class CheckPackages(Adw.Bin):
         vbox.append(header)
         vbox.append(check_snaps_row)
         vbox.append(check_debs_row)
-        self.set_child(vbox)
+        scrolled_window.set_child(vbox)
+        self.set_child(scrolled_window)
 
     def on_fix_clicked(self, button, package):
         print('on_fix_clicked: ' + package)

--- a/src/finaltest.py
+++ b/src/finaltest.py
@@ -17,10 +17,6 @@ class WizardWindow(Gtk.ApplicationWindow):
 
         self.set_default_size(800, 800)
 
-        # Create scrollable window
-        scrolled_window = Gtk.ScrolledWindow()
-        scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
-
         # Create Gtk.HeaderBar
         header_bar = Gtk.HeaderBar()
         header_bar_title = Gtk.Label(label="Kramden - Final Test")
@@ -51,7 +47,6 @@ class WizardWindow(Gtk.ApplicationWindow):
         self.stack.add_named(self.page4, "page4")
 
         self.stack.set_vexpand(True)  # Ensure the stack expands vertically
-        scrolled_window.set_child(self.stack)
 
         # Create footer
         footer = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
@@ -64,7 +59,7 @@ class WizardWindow(Gtk.ApplicationWindow):
 
         # Content Box
         content_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        content_box.append(scrolled_window)
+        content_box.append(self.stack)
         content_box.append(footer)
 
         self.set_child(content_box)


### PR DESCRIPTION
This isn't perfect, but a decent improvement. Ideally we show split the header for that page out of the scrolled window.