### PR TITLE
Detect HP BIOS password via hp-bioscfg

### DIFF
--- a/scripts/bios_password.sh
+++ b/scripts/bios_password.sh
@@ -8,10 +8,45 @@ else
     dell_admin_pass=""
 fi
 
-if [[ ${#admin_pass} > 0 || ${#dell_admin_pass} > 0 ]];
+hp_admin_pass=""
+hp_unreliable=""
+vendor=$(cat /sys/class/dmi/id/sys_vendor 2>/dev/null)
+if [[ $vendor =~ "HP" || $vendor =~ "Hewlett" ]]; then
+    modprobe hp-bioscfg 2>/dev/null
+    auth_dir=/sys/class/firmware-attributes/hp-bioscfg/authentication
+    if [ -d "$auth_dir" ]; then
+        for f in "$auth_dir"/*/is_enabled; do
+            [ -r "$f" ] || continue
+            val=$(cat "$f" 2>/dev/null)
+            if [ "$val" = "1" ]; then
+                hp_admin_pass="enabled"
+                break
+            fi
+        done
+        # The hp-bioscfg driver creates corrupted entries (e.g. names
+        # containing \r) on some HP firmware, where is_enabled lies and
+        # reads of sibling attributes return I/O errors. If we see any
+        # such entry and didn't already find an is_enabled=1, detection
+        # is unreliable on this machine.
+        if [ -z "$hp_admin_pass" ]; then
+            for d in "$auth_dir"/*/; do
+                name=$(basename "$d")
+                if [[ "$name" != [A-Za-z0-9_]* ]] || ! cat "$d/role" >/dev/null 2>&1; then
+                    hp_unreliable=1
+                    break
+                fi
+            done
+        fi
+    fi
+fi
+
+if [[ ${#admin_pass} > 0 || ${#dell_admin_pass} > 0 || ${#hp_admin_pass} > 0 ]];
 then
     echo "BIOS Password enabled"
     exit 1
 else
+    if [ -n "$hp_unreliable" ]; then
+        echo "WARNING: HP BIOS password state could not be determined reliably on this firmware (hp-bioscfg exposed malformed authentication entries). Verify manually via F10 Setup." >&2
+    fi
     echo "BIOS Password disabled"
 fi

--- a/scripts/bios_password.sh
+++ b/scripts/bios_password.sh
@@ -17,7 +17,10 @@ if [[ $vendor =~ "HP" || $vendor =~ "Hewlett" ]]; then
     if [ -d "$auth_dir" ]; then
         for f in "$auth_dir"/*/is_enabled; do
             [ -r "$f" ] || continue
-            val=$(cat "$f" 2>/dev/null)
+            if ! val=$(cat "$f" 2>/dev/null); then
+                hp_unreliable=1
+                continue
+            fi
             if [ "$val" = "1" ]; then
                 hp_admin_pass="enabled"
                 break

--- a/scripts/bios_password.sh
+++ b/scripts/bios_password.sh
@@ -32,7 +32,7 @@ if [[ $vendor =~ "HP" || $vendor =~ "Hewlett" ]]; then
             for d in "$auth_dir"/*/; do
                 [ -d "$d" ] || continue
                 name=$(basename "$d")
-                if [[ "$name" != [A-Za-z0-9_]* ]] || ! cat "$d/role" >/dev/null 2>&1; then
+                if ! [[ "$name" =~ ^[A-Za-z0-9_]+$ ]] || ! cat "$d/role" >/dev/null 2>&1; then
                     hp_unreliable=1
                     break
                 fi

--- a/scripts/bios_password.sh
+++ b/scripts/bios_password.sh
@@ -30,6 +30,7 @@ if [[ $vendor =~ "HP" || $vendor =~ "Hewlett" ]]; then
         # is unreliable on this machine.
         if [ -z "$hp_admin_pass" ]; then
             for d in "$auth_dir"/*/; do
+                [ -d "$d" ] || continue
                 name=$(basename "$d")
                 if [[ "$name" != [A-Za-z0-9_]* ]] || ! cat "$d/role" >/dev/null 2>&1; then
                     hp_unreliable=1

--- a/src/generate_tracking_sheet.py
+++ b/src/generate_tracking_sheet.py
@@ -72,6 +72,13 @@ def get_system_info():
     else:
         battery_health = None
 
+    if bios_password is True:
+        bios_password_str = "Yes"
+    elif bios_password is None:
+        bios_password_str = "Unverified"
+    else:
+        bios_password_str = "No"
+
     info = {
         "Brand": brand,
         "Model": model,
@@ -79,7 +86,7 @@ def get_system_info():
         "RAM": ram,  # Numeric value only
         "Storage": total_storage,
         "Serial# Scanner": serial,
-        "BIOS Password": "Yes" if bios_password is True else "Unverified" if bios_password is None else "No",
+        "BIOS Password": bios_password_str,
         "Asset Info": "Yes" if asset_info else "No",
     }
 

--- a/src/generate_tracking_sheet.py
+++ b/src/generate_tracking_sheet.py
@@ -79,7 +79,7 @@ def get_system_info():
         "RAM": ram,  # Numeric value only
         "Storage": total_storage,
         "Serial# Scanner": serial,
-        "BIOS Password": "Yes" if bios_password else "No",
+        "BIOS Password": "Yes" if bios_password is True else "Unverified" if bios_password is None else "No",
         "Asset Info": "Yes" if asset_info else "No",
     }
 

--- a/src/specinfo.py
+++ b/src/specinfo.py
@@ -151,8 +151,11 @@ class SpecInfo(Adw.Bin):
 
         bios_password = utils.has_bios_password()
         bios_password_warning = getattr(utils, "bios_password_warning", None)
-        if bios_password and not self.bios_password_override:
-            self.bios_password_row.set_subtitle("Has Password")
+        bios_password_failure = bios_password or bool(bios_password_warning)
+        if bios_password_failure and not self.bios_password_override:
+            self.bios_password_row.set_subtitle(
+                bios_password_warning if bios_password_warning else "Has Password"
+            )
             self.bios_password_row.set_icon_name("emblem-important-symbolic")
             self.bios_password_row.add_css_class("text-error")
             if not self._bios_password_override_button:
@@ -162,15 +165,15 @@ class SpecInfo(Adw.Bin):
                     self._on_bios_password_override_accepted,
                 )
             passed = False
-        elif bios_password_warning and not bios_password:
-            self.bios_password_row.set_subtitle(bios_password_warning)
-            self.bios_password_row.set_icon_name("dialog-warning-symbolic")
-            if self.bios_password_row.has_css_class("text-error"):
-                self.bios_password_row.remove_css_class("text-error")
         else:
-            self.bios_password_row.set_subtitle(
-                "No Password" if not bios_password else "Has Password (Overridden)"
-            )
+            if not bios_password_failure:
+                self.bios_password_row.set_subtitle("No Password")
+            elif bios_password_warning:
+                self.bios_password_row.set_subtitle(
+                    f"{bios_password_warning} (Overridden)"
+                )
+            else:
+                self.bios_password_row.set_subtitle("Has Password (Overridden)")
             self.bios_password_row.set_icon_name("emblem-ok-symbolic")
             if self.bios_password_row.has_css_class("text-error"):
                 self.bios_password_row.remove_css_class("text-error")

--- a/src/specinfo.py
+++ b/src/specinfo.py
@@ -151,11 +151,9 @@ class SpecInfo(Adw.Bin):
 
         bios_password = utils.has_bios_password()
         bios_password_warning = getattr(utils, "bios_password_warning", None)
-        bios_password_failure = bios_password or bool(bios_password_warning)
-        if bios_password_failure and not self.bios_password_override:
-            self.bios_password_row.set_subtitle(
-                bios_password_warning if bios_password_warning else "Has Password"
-            )
+        if bios_password and not self.bios_password_override:
+            # True: password detected – error state, blocks completion
+            self.bios_password_row.set_subtitle("Has Password")
             self.bios_password_row.set_icon_name("emblem-important-symbolic")
             self.bios_password_row.add_css_class("text-error")
             if not self._bios_password_override_button:
@@ -165,8 +163,21 @@ class SpecInfo(Adw.Bin):
                     self._on_bios_password_override_accepted,
                 )
             passed = False
+        elif bios_password is None and not self.bios_password_override:
+            # None: indeterminate – warning state, does NOT block completion
+            self.bios_password_row.set_subtitle(
+                bios_password_warning or "Could not determine BIOS password state"
+            )
+            self.bios_password_row.set_icon_name("dialog-warning-symbolic")
+            if not self._bios_password_override_button:
+                self._bios_password_override_button = self._add_override_button(
+                    self.bios_password_row,
+                    "BIOS Password Override",
+                    self._on_bios_password_override_accepted,
+                )
         else:
-            if not bios_password_failure:
+            # False (no password) or override accepted
+            if bios_password is False:
                 self.bios_password_row.set_subtitle("No Password")
             elif bios_password_warning:
                 self.bios_password_row.set_subtitle(

--- a/src/specinfo.py
+++ b/src/specinfo.py
@@ -150,6 +150,7 @@ class SpecInfo(Adw.Bin):
             self.mem_row.add_css_class("text-error")
 
         bios_password = utils.has_bios_password()
+        bios_password_warning = getattr(utils, "bios_password_warning", None)
         if bios_password and not self.bios_password_override:
             self.bios_password_row.set_subtitle("Has Password")
             self.bios_password_row.set_icon_name("emblem-important-symbolic")
@@ -161,6 +162,11 @@ class SpecInfo(Adw.Bin):
                     self._on_bios_password_override_accepted,
                 )
             passed = False
+        elif bios_password_warning and not bios_password:
+            self.bios_password_row.set_subtitle(bios_password_warning)
+            self.bios_password_row.set_icon_name("dialog-warning-symbolic")
+            if self.bios_password_row.has_css_class("text-error"):
+                self.bios_password_row.remove_css_class("text-error")
         else:
             self.bios_password_row.set_subtitle(
                 "No Password" if not bios_password else "Has Password (Overridden)"

--- a/src/specinfo.py
+++ b/src/specinfo.py
@@ -176,12 +176,15 @@ class SpecInfo(Adw.Bin):
                     self._on_bios_password_override_accepted,
                 )
         else:
-            # False (no password) or override accepted
+            # Overridden or no password
             if bios_password is False:
                 self.bios_password_row.set_subtitle("No Password")
-            elif bios_password_warning:
+            elif bios_password is None:
+                # Warning state was overridden by operator
                 self.bios_password_row.set_subtitle(
                     f"{bios_password_warning} (Overridden)"
+                    if bios_password_warning
+                    else "BIOS Password State Unknown (Overridden)"
                 )
             else:
                 self.bios_password_row.set_subtitle("Has Password (Overridden)")

--- a/src/utils.py
+++ b/src/utils.py
@@ -137,9 +137,17 @@ class Utils:
         return False
 
     # Check if BIOS Password is set, returns True if set.
-    # When the script can't determine state reliably (e.g. buggy HP firmware
-    # via hp-bioscfg), it prints a WARNING line to stderr; the text of that
-    # warning is captured on self.bios_password_warning for the UI.
+    # Detect whether a BIOS password is set.
+    #
+    # Returns:
+    #   True  – password is set (script exited non-zero)
+    #   False – no password (script exited 0, no warning)
+    #   None  – indeterminate: script exited 0 but emitted a WARNING on stderr
+    #           (e.g. buggy HP firmware via hp-bioscfg).  The warning text is
+    #           stored on self.bios_password_warning for the UI to display.
+    #
+    # Callers that only consume the boolean must treat None as unverified, not
+    # as "no password".
     def has_bios_password(self):
         self.bios_password_warning = None
         bios_password_sh = "/usr/share/kramden-provision/scripts/bios_password.sh"
@@ -151,7 +159,9 @@ class Utils:
                 if line.startswith("WARNING:"):
                     self.bios_password_warning = line[len("WARNING:") :].strip()
                     break
-            return result.returncode != 0
+            if result.returncode != 0:
+                return True
+            return None if self.bios_password_warning else False
         return False
 
     # Check if BIOS has Asset info, returns True if set

--- a/src/utils.py
+++ b/src/utils.py
@@ -136,11 +136,21 @@ class Utils:
             return result.returncode == 0
         return False
 
-    # Check if BIOS Password is set, returns True if set
+    # Check if BIOS Password is set, returns True if set.
+    # When the script can't determine state reliably (e.g. buggy HP firmware
+    # via hp-bioscfg), it prints a WARNING line to stderr; the text of that
+    # warning is captured on self.bios_password_warning for the UI.
     def has_bios_password(self):
+        self.bios_password_warning = None
         bios_password_sh = "/usr/share/kramden-provision/scripts/bios_password.sh"
         if self.file_exists_and_executable(bios_password_sh):
-            result = subprocess.run(["sudo", bios_password_sh])
+            result = subprocess.run(
+                ["sudo", bios_password_sh], capture_output=True, text=True
+            )
+            for line in (result.stderr or "").splitlines():
+                if line.startswith("WARNING:"):
+                    self.bios_password_warning = line[len("WARNING:") :].strip()
+                    break
             return result.returncode != 0
         return False
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1403,13 +1403,13 @@ class TestHasBiosPassword(unittest.TestCase):
     @patch('subprocess.run')
     @patch.object(Utils, 'file_exists_and_executable', return_value=True)
     def test_has_bios_password_warning_on_stderr_exit_zero(self, mock_exists, mock_run):
-        """Exit 0 with a WARNING on stderr captures the warning but returns False."""
+        """Exit 0 with a WARNING on stderr captures the warning and returns None (indeterminate)."""
         mock_run.return_value = MagicMock(
             returncode=0,
             stderr="WARNING: HP BIOS authentication entries may be unreliable; verify via F10\n"
         )
         result = self.utils.has_bios_password()
-        self.assertFalse(result)
+        self.assertIsNone(result)
         self.assertEqual(
             self.utils.bios_password_warning,
             "HP BIOS authentication entries may be unreliable; verify via F10"
@@ -1433,12 +1433,13 @@ class TestHasBiosPassword(unittest.TestCase):
     @patch('subprocess.run')
     @patch.object(Utils, 'file_exists_and_executable', return_value=True)
     def test_has_bios_password_only_first_warning_captured(self, mock_exists, mock_run):
-        """Only the first WARNING line on stderr is captured."""
+        """Only the first WARNING line on stderr is captured; result is None (indeterminate)."""
         mock_run.return_value = MagicMock(
             returncode=0,
             stderr="WARNING: first warning\nWARNING: second warning\n"
         )
-        self.utils.has_bios_password()
+        result = self.utils.has_bios_password()
+        self.assertIsNone(result)
         self.assertEqual(self.utils.bios_password_warning, "first warning")
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1356,5 +1356,91 @@ Memory Device
             self.assertEqual(result, {"BAT0": 87, "BAT1": 78})
 
 
+class TestHasBiosPassword(unittest.TestCase):
+    def setUp(self):
+        hostnamectl_json = {
+            "StaticHostname": "testhost",
+            "OperatingSystemPrettyName": "Test OS 1.0",
+            "HardwareVendor": "Test Vendor",
+            "HardwareModel": "Test Model",
+            "HardwareSerial": "TEST123"
+        }
+        self.mock_subproc_run = patch('subprocess.run').start()
+        mock_result = MagicMock()
+        mock_result.stdout = json.dumps(hostnamectl_json)
+        mock_result.returncode = 0
+        self.mock_subproc_run.return_value = mock_result
+        self.utils = Utils()
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch.object(Utils, 'file_exists_and_executable', return_value=False)
+    def test_has_bios_password_script_not_present(self, mock_exists):
+        """When the script is absent, return False with no warning."""
+        result = self.utils.has_bios_password()
+        self.assertFalse(result)
+        self.assertIsNone(self.utils.bios_password_warning)
+
+    @patch('subprocess.run')
+    @patch.object(Utils, 'file_exists_and_executable', return_value=True)
+    def test_has_bios_password_detected_nonzero_exit(self, mock_exists, mock_run):
+        """A nonzero exit code means a password is set; no warning expected."""
+        mock_run.return_value = MagicMock(returncode=1, stderr="")
+        result = self.utils.has_bios_password()
+        self.assertTrue(result)
+        self.assertIsNone(self.utils.bios_password_warning)
+
+    @patch('subprocess.run')
+    @patch.object(Utils, 'file_exists_and_executable', return_value=True)
+    def test_has_bios_password_not_detected(self, mock_exists, mock_run):
+        """Exit 0 with no stderr means no password and no warning."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        result = self.utils.has_bios_password()
+        self.assertFalse(result)
+        self.assertIsNone(self.utils.bios_password_warning)
+
+    @patch('subprocess.run')
+    @patch.object(Utils, 'file_exists_and_executable', return_value=True)
+    def test_has_bios_password_warning_on_stderr_exit_zero(self, mock_exists, mock_run):
+        """Exit 0 with a WARNING on stderr captures the warning but returns False."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stderr="WARNING: HP BIOS authentication entries may be unreliable; verify via F10\n"
+        )
+        result = self.utils.has_bios_password()
+        self.assertFalse(result)
+        self.assertEqual(
+            self.utils.bios_password_warning,
+            "HP BIOS authentication entries may be unreliable; verify via F10"
+        )
+
+    @patch('subprocess.run')
+    @patch.object(Utils, 'file_exists_and_executable', return_value=True)
+    def test_has_bios_password_warning_on_stderr_nonzero_exit(self, mock_exists, mock_run):
+        """Nonzero exit with a WARNING on stderr still returns True and captures the warning."""
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stderr="WARNING: HP BIOS authentication entries may be unreliable; verify via F10\n"
+        )
+        result = self.utils.has_bios_password()
+        self.assertTrue(result)
+        self.assertEqual(
+            self.utils.bios_password_warning,
+            "HP BIOS authentication entries may be unreliable; verify via F10"
+        )
+
+    @patch('subprocess.run')
+    @patch.object(Utils, 'file_exists_and_executable', return_value=True)
+    def test_has_bios_password_only_first_warning_captured(self, mock_exists, mock_run):
+        """Only the first WARNING line on stderr is captured."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stderr="WARNING: first warning\nWARNING: second warning\n"
+        )
+        self.utils.has_bios_password()
+        self.assertEqual(self.utils.bios_password_warning, "first warning")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Extends `bios_password.sh` with an HP path that loads the `hp-bioscfg` kernel driver and reads `is_enabled` for every entry under `/sys/class/firmware-attributes/hp-bioscfg/authentication/`.
- On HP firmware where the driver exposes malformed authentication entries (corrupted directory names like `\r`, I/O errors when reading sibling attributes) and no `is_enabled=1` was found, the script emits a `WARNING:` line on stderr and continues (exit 0) rather than silently passing.
- `utils.has_bios_password()` captures that stderr warning onto `self.bios_password_warning`; `SpecInfo` surfaces it on the BIOS Password row with `dialog-warning-symbolic` so the operator knows to verify manually via F10.

## Test plan
- [ ] On an HP laptop with hp-bioscfg present and `is_enabled=1`: BIOS Password row shows "Has Password" (error state, override button).
- [ ] On the HP laptop with the malformed-`\r`-entry firmware: BIOS Password row shows the warning subtitle with a warning icon; provisioning is not blocked.
- [ ] On a Dell with `/opt/dell/dcc/cctk` and a BIOS password: existing Dell behavior unchanged.
- [ ] On a non-HP/Dell machine: lshw-based detection unchanged.