### PR TITLE
Stream stdout during SpecInfo/SysInfo gather; lock Next while loading

### DIFF
--- a/src/finaltest.py
+++ b/src/finaltest.py
@@ -70,6 +70,8 @@ class WizardWindow(Gtk.ApplicationWindow):
         self.page4 = FinalTestComplete()
 
         self.page1.state = self.observable_property
+        self.page1.on_loading_changed = self._on_sysinfo_loading_changed
+        self._sysinfo_loading = False
         self.page2.state = self.observable_property
         self.page3.state = self.observable_property
         self.page4.manual_test = self.page3
@@ -160,8 +162,18 @@ class WizardWindow(Gtk.ApplicationWindow):
             self.next_button.remove_css_class("button-next-last-page")
             self.next_button.set_label("Next")
 
+        # While SysInfo is gathering, lock Next/Prev so rapid clicks
+        # don't queue and fire after the page finishes loading.
+        if self._sysinfo_loading:
+            self.next_button.set_sensitive(False)
+            self.prev_button.set_sensitive(False)
+
         # Focus the next button
         self.next_button.grab_focus()
+
+    def _on_sysinfo_loading_changed(self, loading):
+        self._sysinfo_loading = loading
+        self.update_buttons()
 
     def complete(self):
         print("Complete Clicked")

--- a/src/knum.py
+++ b/src/knum.py
@@ -117,16 +117,11 @@ class KramdenNumber(Adw.Bin):
             self._lookup_done = True
             return
 
-        self._set_status(f"Looking up serial '{serial}' in Sortly...")
-        self.spinner.set_visible(True)
-        self.spinner.start()
-
-        thread = threading.Thread(
-            target=self._lookup_serial_thread,
-            args=(api_key, serial),
-            daemon=True,
+        # Temporarily disable the automatic serial lookup at startup in OSLoad.
+        self._lookup_done = True
+        self._set_status(
+            "Automatic serial lookup is temporarily disabled. Enter a K-number to continue."
         )
-        thread.start()
 
     def _lookup_serial_thread(self, api_key, serial):
         try:

--- a/src/loading_capture.py
+++ b/src/loading_capture.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import threading
+
+
+class StdoutCapture:
+    """Redirect fd 1 (and sys.stdout) to a pipe; deliver lines to a callback.
+
+    Captures both Python prints and subprocess stdout that inherits fd 1.
+    The callback runs on the reader thread — push to GLib.idle_add for UI.
+    """
+
+    def __init__(self, on_line):
+        self._on_line = on_line
+        self._saved_fd1 = None
+        self._saved_stdout = None
+        self._read_fd = None
+        self._reader_thread = None
+
+    def start(self):
+        r, w = os.pipe()
+        self._read_fd = r
+        self._saved_fd1 = os.dup(1)
+        try:
+            sys.stdout.flush()
+        except Exception:
+            pass
+        os.dup2(w, 1)
+        os.close(w)
+        self._saved_stdout = sys.stdout
+        sys.stdout = os.fdopen(1, "w", buffering=1, closefd=False)
+        self._reader_thread = threading.Thread(target=self._reader, daemon=True)
+        self._reader_thread.start()
+
+    def _reader(self):
+        try:
+            with os.fdopen(self._read_fd, "r", buffering=1) as f:
+                for line in f:
+                    self._on_line(line)
+        except Exception:
+            pass
+
+    def stop(self):
+        try:
+            sys.stdout.flush()
+        except Exception:
+            pass
+        sys.stdout = self._saved_stdout
+        os.dup2(self._saved_fd1, 1)
+        os.close(self._saved_fd1)
+        # Reader thread sees EOF and exits on its own.

--- a/src/meson.build
+++ b/src/meson.build
@@ -67,6 +67,7 @@ sources = [
   'osloadcomplete.py',
   'osload.py',
   'sortly.py',
+  'loading_capture.py',
   'sortly_register.py',
   'sortly_lookup_by_name.py',
   'sortly_lookup_by_serial.py',

--- a/src/osload.py
+++ b/src/osload.py
@@ -73,6 +73,8 @@ class WizardWindow(Gtk.ApplicationWindow):
         self.page1.state = self.observable_property
         self.page2.state = self.observable_property
         self.page3.state = self.observable_property
+        self.page3.on_loading_changed = self._on_sysinfo_loading_changed
+        self._sysinfo_loading = False
         self.page4.state = self.observable_property
 
         # Expose next button function
@@ -163,8 +165,18 @@ class WizardWindow(Gtk.ApplicationWindow):
             self.next_button.remove_css_class("button-next-last-page")
             self.next_button.set_label("Next")
 
+        # While SysInfo is gathering, lock Next/Prev so rapid clicks
+        # don't queue and fire after the page finishes loading.
+        if self._sysinfo_loading:
+            self.next_button.set_sensitive(False)
+            self.prev_button.set_sensitive(False)
+
         if self.current_page == 2:
             self.next_button.grab_focus()
+
+    def _on_sysinfo_loading_changed(self, loading):
+        self._sysinfo_loading = loading
+        self.update_buttons()
 
     def complete(self):
         print("Complete Clicked")

--- a/src/spec.py
+++ b/src/spec.py
@@ -73,6 +73,8 @@ class WizardWindow(Gtk.ApplicationWindow):
         self.page1.state = self.observable_property
         self.page2.sortly_register = self.page1
         self.page2.state = self.observable_property
+        self.page2.on_loading_changed = self._on_specinfo_loading_changed
+        self._specinfo_loading = False
         self.page3.state = self.observable_property
         self.page4.sortly_register = self.page1
         self.page4.manual_test = self.page3
@@ -188,8 +190,18 @@ class WizardWindow(Gtk.ApplicationWindow):
             self.next_button.remove_css_class("button-next-last-page")
             self.next_button.set_label("Next")
 
+        # While SpecInfo is gathering data, lock Next so rapid clicks
+        # don't queue and fire after the page finishes loading.
+        if self._specinfo_loading:
+            self.next_button.set_sensitive(False)
+            self.prev_button.set_sensitive(False)
+
         # Focus the next button
         self.next_button.grab_focus()
+
+    def _on_specinfo_loading_changed(self, loading):
+        self._specinfo_loading = loading
+        self.update_buttons()
 
     def complete(self):
         print("Complete Clicked")

--- a/src/specinfo.py
+++ b/src/specinfo.py
@@ -1,5 +1,3 @@
-import os
-import sys
 import threading
 
 import gi
@@ -7,55 +5,8 @@ import gi
 gi.require_version("Adw", "1")
 gi.require_version("Gtk", "4.0")
 from gi.repository import Adw, GLib, Gtk
+from loading_capture import StdoutCapture
 from utils import Utils
-
-
-class _StdoutCapture:
-    """Redirect fd 1 (and sys.stdout) to a pipe; deliver lines to a callback.
-
-    Captures both Python prints and subprocess stdout that inherits fd 1.
-    The callback runs on the reader thread — push to GLib.idle_add for UI.
-    """
-
-    def __init__(self, on_line):
-        self._on_line = on_line
-        self._saved_fd1 = None
-        self._saved_stdout = None
-        self._read_fd = None
-        self._reader_thread = None
-
-    def start(self):
-        r, w = os.pipe()
-        self._read_fd = r
-        self._saved_fd1 = os.dup(1)
-        try:
-            sys.stdout.flush()
-        except Exception:
-            pass
-        os.dup2(w, 1)
-        os.close(w)
-        self._saved_stdout = sys.stdout
-        sys.stdout = os.fdopen(1, "w", buffering=1, closefd=False)
-        self._reader_thread = threading.Thread(target=self._reader, daemon=True)
-        self._reader_thread.start()
-
-    def _reader(self):
-        try:
-            with os.fdopen(self._read_fd, "r", buffering=1) as f:
-                for line in f:
-                    self._on_line(line)
-        except Exception:
-            pass
-
-    def stop(self):
-        try:
-            sys.stdout.flush()
-        except Exception:
-            pass
-        sys.stdout = self._saved_stdout
-        os.dup2(self._saved_fd1, 1)
-        os.close(self._saved_fd1)
-        # Reader thread sees EOF and exits on its own.
 
 
 class SpecInfo(Adw.Bin):
@@ -228,7 +179,7 @@ class SpecInfo(Adw.Bin):
         if self.on_loading_changed:
             self.on_loading_changed(True)
 
-        self._stdout_capture = _StdoutCapture(self._on_stdout_line)
+        self._stdout_capture = StdoutCapture(self._on_stdout_line)
         self._stdout_capture.start()
 
         threading.Thread(target=self._gather_thread, daemon=True).start()

--- a/src/specinfo.py
+++ b/src/specinfo.py
@@ -250,9 +250,13 @@ class SpecInfo(Adw.Bin):
         self._loading_spinner.stop()
         self._loading_box.set_visible(False)
         self._list_box.set_visible(True)
-        self._render()
-        if self.on_loading_changed:
-            self.on_loading_changed(False)
+        try:
+            self._render()
+        except Exception as exc:
+            print(f"SpecInfo._render failed: {exc}")
+        finally:
+            if self.on_loading_changed:
+                self.on_loading_changed(False)
         return False
 
     def _render(self):

--- a/src/specinfo.py
+++ b/src/specinfo.py
@@ -1,15 +1,66 @@
+import os
+import sys
+import threading
+
 import gi
 
 gi.require_version("Adw", "1")
 gi.require_version("Gtk", "4.0")
-from gi.repository import Adw, Gtk
+from gi.repository import Adw, GLib, Gtk
 from utils import Utils
+
+
+class _StdoutCapture:
+    """Redirect fd 1 (and sys.stdout) to a pipe; deliver lines to a callback.
+
+    Captures both Python prints and subprocess stdout that inherits fd 1.
+    The callback runs on the reader thread — push to GLib.idle_add for UI.
+    """
+
+    def __init__(self, on_line):
+        self._on_line = on_line
+        self._saved_fd1 = None
+        self._saved_stdout = None
+        self._read_fd = None
+        self._reader_thread = None
+
+    def start(self):
+        r, w = os.pipe()
+        self._read_fd = r
+        self._saved_fd1 = os.dup(1)
+        try:
+            sys.stdout.flush()
+        except Exception:
+            pass
+        os.dup2(w, 1)
+        os.close(w)
+        self._saved_stdout = sys.stdout
+        sys.stdout = os.fdopen(1, "w", buffering=1, closefd=False)
+        self._reader_thread = threading.Thread(target=self._reader, daemon=True)
+        self._reader_thread.start()
+
+    def _reader(self):
+        try:
+            with os.fdopen(self._read_fd, "r", buffering=1) as f:
+                for line in f:
+                    self._on_line(line)
+        except Exception:
+            pass
+
+    def stop(self):
+        try:
+            sys.stdout.flush()
+        except Exception:
+            pass
+        sys.stdout = self._saved_stdout
+        os.dup2(self._saved_fd1, 1)
+        os.close(self._saved_fd1)
+        # Reader thread sees EOF and exits on its own.
 
 
 class SpecInfo(Adw.Bin):
     def __init__(self):
         super().__init__()
-        utils = Utils()
         self.set_margin_top(20)
         self.set_margin_bottom(20)
         self.set_margin_start(20)
@@ -26,6 +77,18 @@ class SpecInfo(Adw.Bin):
         self._bios_password_override_button = None
         self._asset_info_override_button = None
         self.sortly_register = None
+
+        # Loading state: data is gathered once in a background thread on first
+        # show. Until ready, the nested loading view (spinner + stdout) covers
+        # the content. on_loading_changed(loading: bool) lets the wizard
+        # disable the Next button while we work.
+        self._data_ready = False
+        self._gather_in_progress = False
+        self._gathered = {}
+        self._stdout_capture = None
+        self.on_loading_changed = None
+
+        utils = Utils()
 
         # Create a box to hold the content
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
@@ -110,16 +173,139 @@ class SpecInfo(Adw.Bin):
         list_box.append(self.disks_box)
         list_box.append(self.battery_row)
 
+        # Nested loading view: spinner + live stdout TextView. Visible
+        # while gather() runs in a background thread; hidden once data
+        # is ready and the rows below are populated.
+        self._loading_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+
+        loading_header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        self._loading_spinner = Gtk.Spinner()
+        self._loading_spinner.set_size_request(24, 24)
+        loading_label = Gtk.Label(label="Gathering system information...")
+        loading_label.add_css_class("title-3")
+        loading_label.set_halign(Gtk.Align.START)
+        loading_header.append(self._loading_spinner)
+        loading_header.append(loading_label)
+        self._loading_box.append(loading_header)
+
+        self._loading_buffer = Gtk.TextBuffer()
+        self._loading_textview = Gtk.TextView(buffer=self._loading_buffer)
+        self._loading_textview.set_editable(False)
+        self._loading_textview.set_cursor_visible(False)
+        self._loading_textview.set_monospace(True)
+        self._loading_textview.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        loading_scroll = Gtk.ScrolledWindow()
+        loading_scroll.set_policy(
+            Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC
+        )
+        loading_scroll.set_min_content_height(320)
+        loading_scroll.set_vexpand(True)
+        loading_scroll.set_child(self._loading_textview)
+        self._loading_box.append(loading_scroll)
+        self._loading_box.set_visible(False)
+
+        self._list_box = list_box
+
+        vbox.append(self._loading_box)
         vbox.append(list_box)
         scrolled_window.set_child(vbox)
         self.set_child(scrolled_window)
 
-    # on_shown is called when the page is shown in the stack
     def on_shown(self):
-        utils = Utils()
-        utils.sync_clock()
+        if self._gather_in_progress:
+            return
+        if not self._data_ready:
+            self._start_gather()
+            return
+        self._render()
 
-        # Start with default of passed and set to False if we find any failures
+    def _start_gather(self):
+        self._gather_in_progress = True
+        self._list_box.set_visible(False)
+        self._loading_box.set_visible(True)
+        self._loading_spinner.start()
+        self._loading_buffer.set_text("")
+        if self.on_loading_changed:
+            self.on_loading_changed(True)
+
+        self._stdout_capture = _StdoutCapture(self._on_stdout_line)
+        self._stdout_capture.start()
+
+        threading.Thread(target=self._gather_thread, daemon=True).start()
+
+    def _gather_thread(self):
+        try:
+            self.gather()
+        except Exception as exc:
+            print(f"Error gathering system info: {exc}")
+        finally:
+            GLib.idle_add(self._on_gather_complete)
+
+    def gather(self):
+        """Heavy data collection. Runs on a background thread. Stores
+        results in self._gathered. Uses print() narration so the user can
+        see progress in the loading TextView while subprocess scripts run.
+        """
+        utils = Utils()
+        print("Syncing system clock...")
+        utils.sync_clock()
+        print("Reading memory size...")
+        mem = utils.get_mem()
+        print("Checking BIOS password (this can be slow)...")
+        bios_password = utils.has_bios_password()
+        bios_password_warning = getattr(utils, "bios_password_warning", None)
+        print(f"  BIOS password: {bios_password}")
+        print("Checking asset info...")
+        asset_info = utils.has_asset_info()
+        print(f"  Asset info: {asset_info}")
+        print("Checking Computrace/Absolute status...")
+        computrace = utils.has_computrace_enabled()
+        print(f"  Computrace: {computrace}")
+        print("Enumerating disks...")
+        disks = utils.get_disks()
+        print(f"  Found {len(disks)} disk(s)")
+        print("Reading battery capacities...")
+        batteries = utils.get_battery_capacities()
+        print(f"  Found {len(batteries)} batter(y/ies)")
+        print("System information gathering complete.")
+
+        self._gathered = {
+            "mem": mem,
+            "bios_password": bios_password,
+            "bios_password_warning": bios_password_warning,
+            "asset_info": asset_info,
+            "computrace": computrace,
+            "disks": disks,
+            "batteries": batteries,
+        }
+
+    def _on_stdout_line(self, line):
+        # Called on the reader thread. Hop to main thread for UI updates.
+        GLib.idle_add(self._append_stdout, line)
+
+    def _append_stdout(self, line):
+        end = self._loading_buffer.get_end_iter()
+        self._loading_buffer.insert(end, line)
+        mark = self._loading_buffer.get_insert()
+        self._loading_textview.scroll_to_mark(mark, 0.0, False, 0.0, 0.0)
+        return False
+
+    def _on_gather_complete(self):
+        if self._stdout_capture is not None:
+            self._stdout_capture.stop()
+            self._stdout_capture = None
+        self._gather_in_progress = False
+        self._data_ready = True
+        self._loading_spinner.stop()
+        self._loading_box.set_visible(False)
+        self._list_box.set_visible(True)
+        self._render()
+        if self.on_loading_changed:
+            self.on_loading_changed(False)
+        return False
+
+    def _render(self):
+        # Widget update only; reads from self._gathered. Runs on main thread.
         passed = True
 
         # Read K-Number from the Sortly registration page
@@ -140,7 +326,7 @@ class SpecInfo(Adw.Bin):
             self.knumber_row.add_css_class("text-error")
 
         # Set Memory row to emblem-ok-symbolic if memory is greater than or equal to 7 GB, else set row to emblem-important-symbolic
-        mem = int(utils.get_mem())
+        mem = int(self._gathered["mem"])
         if mem >= 7:
             self.mem_row.set_icon_name("emblem-ok-symbolic")
             if self.mem_row.has_css_class("text-error"):
@@ -149,8 +335,8 @@ class SpecInfo(Adw.Bin):
             self.mem_row.set_icon_name("emblem-important-symbolic")
             self.mem_row.add_css_class("text-error")
 
-        bios_password = utils.has_bios_password()
-        bios_password_warning = getattr(utils, "bios_password_warning", None)
+        bios_password = self._gathered["bios_password"]
+        bios_password_warning = self._gathered.get("bios_password_warning")
         if bios_password and not self.bios_password_override:
             # True: password detected – error state, blocks completion
             self.bios_password_row.set_subtitle("Has Password")
@@ -192,7 +378,7 @@ class SpecInfo(Adw.Bin):
             if self.bios_password_row.has_css_class("text-error"):
                 self.bios_password_row.remove_css_class("text-error")
 
-        asset_info = utils.has_asset_info()
+        asset_info = self._gathered["asset_info"]
         if asset_info and not self.asset_info_override:
             self.asset_info_row.set_subtitle("Has Asset Info")
             self.asset_info_row.set_icon_name("emblem-important-symbolic")
@@ -212,7 +398,7 @@ class SpecInfo(Adw.Bin):
             if self.asset_info_row.has_css_class("text-error"):
                 self.asset_info_row.remove_css_class("text-error")
 
-        computrace_activated = utils.has_computrace_enabled()
+        computrace_activated = self._gathered["computrace"]
         if computrace_activated is True:
             self.computrace_row.set_subtitle("Activated")
             self.computrace_row.set_icon_name("emblem-important-symbolic")
@@ -227,7 +413,7 @@ class SpecInfo(Adw.Bin):
 
         # Populate disk information
         if not self.disks_populated:
-            disks = utils.get_disks()
+            disks = self._gathered["disks"]
             if len(disks.keys()) > 0:
                 self.has_disks = True
             if len(disks.keys()) > 1:
@@ -279,7 +465,7 @@ class SpecInfo(Adw.Bin):
         # Populate battery information
         if not self.batteries_populated:
             # Populate battery info
-            batteries = utils.get_battery_capacities()
+            batteries = self._gathered["batteries"]
             if len(batteries) == 1:
                 self.battery_row.set_title("Battery")
             for battery in batteries.keys():
@@ -299,7 +485,7 @@ class SpecInfo(Adw.Bin):
 
         state = self.state.get_value()
         state["SpecInfo"] = passed
-        print("specinfo:on_shown " + str(self.state.get_value()))
+        print("specinfo:_render " + str(self.state.get_value()))
 
     def _add_override_button(self, parent_row, dialog_title, on_accepted):
         """Add an Override button to the given row. Returns the button."""

--- a/src/sysinfo.py
+++ b/src/sysinfo.py
@@ -212,9 +212,13 @@ class SysInfo(Adw.Bin):
         self._loading_spinner.stop()
         self._loading_box.set_visible(False)
         self._list_box.set_visible(True)
-        self._render()
-        if self.on_loading_changed:
-            self.on_loading_changed(False)
+        try:
+            self._render()
+        except Exception as exc:
+            print(f"SysInfo._render failed: {exc}")
+        finally:
+            if self.on_loading_changed:
+                self.on_loading_changed(False)
         return False
 
     def _render(self):

--- a/src/sysinfo.py
+++ b/src/sysinfo.py
@@ -1,15 +1,17 @@
+import threading
+
 import gi
 
 gi.require_version("Adw", "1")
 gi.require_version("Gtk", "4.0")
-from gi.repository import Adw, Gtk
+from gi.repository import Adw, GLib, Gtk
+from loading_capture import StdoutCapture
 from utils import Utils
 
 
 class SysInfo(Adw.Bin):
     def __init__(self):
         super().__init__()
-        utils = Utils()
         self.set_margin_top(20)
         self.set_margin_bottom(20)
         self.set_margin_start(20)
@@ -18,6 +20,18 @@ class SysInfo(Adw.Bin):
         self.skip = False
         self.batteries_populated = False
         self.disks_populated = False
+
+        # Loading state: data is gathered once in a background thread on
+        # first show. Until ready, the nested loading view (spinner +
+        # stdout) covers the content. on_loading_changed(loading: bool)
+        # lets the wizard disable Next/Prev while we work.
+        self._data_ready = False
+        self._gather_in_progress = False
+        self._gathered = {}
+        self._stdout_capture = None
+        self.on_loading_changed = None
+
+        utils = Utils()
 
         # Create a box to hold the content
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
@@ -40,19 +54,16 @@ class SysInfo(Adw.Bin):
         vendor_row = Adw.ActionRow()
         vendor_row.set_title("Manufacturer")
         vendor_row.set_subtitle(utils.get_vendor())
-        # Set vendor row to emblem-ok-symbolic
         vendor_row.set_icon_name("emblem-ok-symbolic")
 
         model_row = Adw.ActionRow()
         model_row.set_title("Model")
         model_row.set_subtitle(utils.get_model())
-        # Set Model row to emblem-ok-symbolic
         model_row.set_icon_name("emblem-ok-symbolic")
 
         os_row = Adw.ActionRow()
         os_row.set_title("OS")
         os_row.set_subtitle(utils.get_os())
-        # Set OS row to emblem-ok-symbolic if the OS is Ubuntu, else set row to emblem-important-symbolic
         if "Ubuntu" in os_row.get_subtitle():
             os_row.set_icon_name("emblem-ok-symbolic")
         else:
@@ -61,7 +72,6 @@ class SysInfo(Adw.Bin):
         cpu_row = Adw.ActionRow()
         cpu_row.set_title("CPU")
         cpu_row.set_subtitle(utils.get_cpu_info())
-        # Set CPU row to emblem-ok-symbolic
         cpu_row.set_icon_name("emblem-ok-symbolic")
 
         self.mem_row = Adw.ActionRow()
@@ -69,9 +79,6 @@ class SysInfo(Adw.Bin):
         self.mem_row.set_subtitle(utils.get_mem() + " GB")
 
         self.disks_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        # self.disk_row = Adw.ExpanderRow(title="Disks")
-        # self.disk_row.set_visible(False)
-        # self.disk_row.set_expanded(False)
 
         self.battery_row = Adw.ExpanderRow(title="Batteries")
         self.battery_row.set_visible(False)
@@ -88,18 +95,131 @@ class SysInfo(Adw.Bin):
         list_box.append(self.disks_box)
         list_box.append(self.battery_row)
 
+        # Nested loading view: spinner + live stdout TextView. Visible
+        # while gather() runs in a background thread; hidden once data
+        # is ready and the rows below are populated.
+        self._loading_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+
+        loading_header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        self._loading_spinner = Gtk.Spinner()
+        self._loading_spinner.set_size_request(24, 24)
+        loading_label = Gtk.Label(label="Gathering system information...")
+        loading_label.add_css_class("title-3")
+        loading_label.set_halign(Gtk.Align.START)
+        loading_header.append(self._loading_spinner)
+        loading_header.append(loading_label)
+        self._loading_box.append(loading_header)
+
+        self._loading_buffer = Gtk.TextBuffer()
+        self._loading_textview = Gtk.TextView(buffer=self._loading_buffer)
+        self._loading_textview.set_editable(False)
+        self._loading_textview.set_cursor_visible(False)
+        self._loading_textview.set_monospace(True)
+        self._loading_textview.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        loading_scroll = Gtk.ScrolledWindow()
+        loading_scroll.set_policy(
+            Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC
+        )
+        loading_scroll.set_min_content_height(320)
+        loading_scroll.set_vexpand(True)
+        loading_scroll.set_child(self._loading_textview)
+        self._loading_box.append(loading_scroll)
+        self._loading_box.set_visible(False)
+
+        self._list_box = list_box
+
+        vbox.append(self._loading_box)
         vbox.append(list_box)
         scrolled_window.set_child(vbox)
         self.set_child(scrolled_window)
 
-    # on_shown is called when the page is shown in the stack
     def on_shown(self):
-        utils = Utils()
+        if self._gather_in_progress:
+            return
+        if not self._data_ready:
+            self._start_gather()
+            return
+        self._render()
 
-        # Start with default of passed and set to False if we find any failures
+    def _start_gather(self):
+        self._gather_in_progress = True
+        self._list_box.set_visible(False)
+        self._loading_box.set_visible(True)
+        self._loading_spinner.start()
+        self._loading_buffer.set_text("")
+        if self.on_loading_changed:
+            self.on_loading_changed(True)
+
+        self._stdout_capture = StdoutCapture(self._on_stdout_line)
+        self._stdout_capture.start()
+
+        threading.Thread(target=self._gather_thread, daemon=True).start()
+
+    def _gather_thread(self):
+        try:
+            self.gather()
+        except Exception as exc:
+            print(f"Error gathering system info: {exc}")
+        finally:
+            GLib.idle_add(self._on_gather_complete)
+
+    def gather(self):
+        """Heavy data collection. Runs on a background thread. Stores
+        results in self._gathered. Uses print() narration so the user
+        sees progress in the loading TextView.
+        """
+        utils = Utils()
+        print("Reading hostname...")
+        hostname = utils.get_hostname()
+        print(f"  hostname: {hostname}")
+        print("Checking Landscape registration...")
+        registered = utils.is_registered()
+        print(f"  registered: {registered}")
+        print("Reading memory size...")
+        mem = utils.get_mem()
+        print("Enumerating disks...")
+        disks = utils.get_disks()
+        print(f"  Found {len(disks)} disk(s)")
+        print("Reading battery capacities...")
+        batteries = utils.get_battery_capacities()
+        print(f"  Found {len(batteries)} batter(y/ies)")
+        print("System information gathering complete.")
+
+        self._gathered = {
+            "hostname": hostname,
+            "registered": registered,
+            "mem": mem,
+            "disks": disks,
+            "batteries": batteries,
+        }
+
+    def _on_stdout_line(self, line):
+        GLib.idle_add(self._append_stdout, line)
+
+    def _append_stdout(self, line):
+        end = self._loading_buffer.get_end_iter()
+        self._loading_buffer.insert(end, line)
+        mark = self._loading_buffer.get_insert()
+        self._loading_textview.scroll_to_mark(mark, 0.0, False, 0.0, 0.0)
+        return False
+
+    def _on_gather_complete(self):
+        if self._stdout_capture is not None:
+            self._stdout_capture.stop()
+            self._stdout_capture = None
+        self._gather_in_progress = False
+        self._data_ready = True
+        self._loading_spinner.stop()
+        self._loading_box.set_visible(False)
+        self._list_box.set_visible(True)
+        self._render()
+        if self.on_loading_changed:
+            self.on_loading_changed(False)
+        return False
+
+    def _render(self):
         passed = True
-        self.hostname_row.set_subtitle(utils.get_hostname())
-        # If the K-Number doesn't start with a "k" show a problem
+        self.hostname_row.set_subtitle(self._gathered["hostname"])
         if self.hostname_row.get_subtitle().lower().startswith("k"):
             self.hostname_row.set_icon_name("emblem-ok-symbolic")
             if self.hostname_row.has_css_class("text-error"):
@@ -110,7 +230,7 @@ class SysInfo(Adw.Bin):
             passed = False
 
         # Landscape registration status
-        if utils.is_registered():
+        if self._gathered["registered"]:
             self.landscape_row.set_subtitle("Registered")
             self.landscape_row.set_icon_name("emblem-ok-symbolic")
             if self.landscape_row.has_css_class("text-error"):
@@ -122,7 +242,7 @@ class SysInfo(Adw.Bin):
             passed = False
 
         # Set Memory row to emblem-ok-symbolic if memory is greater than or equal to 7 GB, else set row to emblem-important-symbolic
-        mem = int(utils.get_mem())
+        mem = int(self._gathered["mem"])
         if mem >= 7:
             self.mem_row.set_icon_name("emblem-ok-symbolic")
             if self.mem_row.has_css_class("text-error"):
@@ -133,7 +253,7 @@ class SysInfo(Adw.Bin):
 
         # Populate disk information
         if not self.disks_populated:
-            disks = utils.get_disks()
+            disks = self._gathered["disks"]
             if len(disks.keys()) > 1:
                 disks_row = Adw.ExpanderRow(title="Disks")
                 disks_row.set_visible(True)
@@ -167,13 +287,11 @@ class SysInfo(Adw.Bin):
                     row.add_css_class("text-error")
                 disk_row.add_row(row)
                 self.disks_box.append(disk_row)
-            # Ensure we only create disk info once
             self.disks_populated = True
 
         # Populate battery information
         if not self.batteries_populated:
-            # Populate battery info
-            batteries = utils.get_battery_capacities()
+            batteries = self._gathered["batteries"]
             if len(batteries) == 1:
                 self.battery_row.set_title("Battery")
             for battery in batteries.keys():
@@ -182,15 +300,13 @@ class SysInfo(Adw.Bin):
                 row.set_subtitle(f"Capacity: {str(batteries[battery])}%")
                 self.battery_row.add_row(row)
                 self.battery_row.set_expanded(True)
-                # Set Battery row to emblem-ok-symbolic if battery capacity is greater than 70%, else set row to emblem-important-symbolic
                 if int(batteries[battery]) >= 70:
                     row.set_icon_name("emblem-ok-symbolic")
                 else:
                     row.set_icon_name("emblem-important-symbolic")
                 self.battery_row.set_visible(True)
-            # Ensure we only create battery info once
             self.batteries_populated = True
 
         state = self.state.get_value()
         state["SysInfo"] = passed
-        print("sysinfo:on_shown " + str(self.state.get_value()))
+        print("sysinfo:_render " + str(self.state.get_value()))


### PR DESCRIPTION
## Summary
- `SpecInfo.on_shown` and `SysInfo.on_shown` ran several slow subprocess-backed `Utils` calls synchronously on the GTK main thread, freezing the UI for up to ~30s and letting Next clicks queue up and fire after the page rendered.
- Split the slow work into a `gather()` phase that runs on a background thread and a `_render()` phase that updates widgets on the main thread from cached results.
- While `gather()` runs, a nested loading view (spinner + monospaced TextView) is visible at the top of the page; a process-wide fd 1 redirect feeds it both Python prints and any subprocess output that inherits stdout.
- New shared helper `src/loading_capture.py` (`StdoutCapture`) backs both pages.
- Wizards (`spec.py`, `osload.py`, `finaltest.py`) lock Next and Previous via an `on_loading_changed` callback so rapid clicks no longer queue.
- `_render` is wrapped in try/finally so the loading state is always cleared even if it raises.
- Disable the automatic Sortly serial lookup at startup in OSLoad's `KramdenNumber` page, mirroring the existing disable in `SortlyRegister`.

## Test plan
- [ ] Launch `kramden-spec` on a real machine with BIOS password / asset info / Computrace checks: SpecInfo should show the spinner + streamed stdout, then render rows; Next stays disabled during gather.
- [ ] Launch `kramden-finaltest` (SysInfo is page 1): startup shows the loading view briefly, then renders; Next re-enables when done.
- [ ] Launch `kramden-osload`, advance to SysInfo (page 3): same behavior.
- [ ] Confirm OSLoad's `KramdenNumber` no longer auto-queries Sortly on startup when an EFI K-number is present.
- [ ] Verify rapid Next clicks during gather no longer skip past pages once loading finishes.
- [ ] Force a failure in `gather()` (e.g., raise) and confirm Next/Prev still re-enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)