### PR TITLE
Touchscreen test: fix GC race and isolate in subprocess

### DIFF
--- a/src/manualtest.py
+++ b/src/manualtest.py
@@ -508,6 +508,10 @@ class TouchscreenTest(Gtk.Window):
     TARGET_SIZE = 60  # diameter of each touch target
     REPOSITION_DELAY_MS = 16
 
+    # Track which displays already have our CSS provider registered, so
+    # we don't accumulate one per TouchscreenTest instance.
+    _css_registered_displays = set()
+
     def __init__(self, parent, callback):
         super().__init__()
         self._callback = callback
@@ -515,19 +519,25 @@ class TouchscreenTest(Gtk.Window):
         self._finish_source_id = None
         self.set_decorated(False)
 
-        # Load CSS for target styling
-        css = Gtk.CssProvider()
-        css.load_from_string(
-            "window.touchscreen-test { background-color: white; }"
-            ".touchscreen-instructions { color: #1f1f1f; font-size: 22px; "
-            "font-weight: bold; }"
-            ".touch-target { background: #4d4d4d; border-radius: 50%; "
-            "min-width: 60px; min-height: 60px; border: none; padding: 0; }"
-            ".touch-target.touched { background: #33cc33; }"
-        )
-        Gtk.StyleContext.add_provider_for_display(
-            parent.get_display(), css, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
-        )
+        # Load CSS for target styling. Register the provider on the
+        # display only once per process; re-registering on every test
+        # accumulates providers and keeps stale references alive.
+        display = parent.get_display()
+        display_id = id(display)
+        if display_id not in TouchscreenTest._css_registered_displays:
+            css = Gtk.CssProvider()
+            css.load_from_string(
+                "window.touchscreen-test { background-color: white; }"
+                ".touchscreen-instructions { color: #1f1f1f; font-size: 22px; "
+                "font-weight: bold; }"
+                ".touch-target { background: #4d4d4d; border-radius: 50%; "
+                "min-width: 60px; min-height: 60px; border: none; padding: 0; }"
+                ".touch-target.touched { background: #33cc33; }"
+            )
+            Gtk.StyleContext.add_provider_for_display(
+                display, css, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+            )
+            TouchscreenTest._css_registered_displays.add(display_id)
 
         self.add_css_class("touchscreen-test")
 
@@ -575,9 +585,12 @@ class TouchscreenTest(Gtk.Window):
         self.connect("map", self._on_map)
         self.connect("close-request", self._on_close_request)
 
-        self.fullscreen()
-
     def _on_map(self, widget):
+        # Defer fullscreen until after map: if a USB input device was
+        # just removed, GDK's device list needs time to settle before a
+        # pointer grab. Calling fullscreen() from __init__ can SIGSEGV
+        # in that window.
+        self.fullscreen()
         self._queue_reposition_targets()
 
     def _on_layout_changed(self, *args):

--- a/src/manualtest.py
+++ b/src/manualtest.py
@@ -388,6 +388,14 @@ class ManualTest(Adw.Bin):
     def on_touchscreen_clicked(self, button):
         print("ManualTest:on_touchscreen_clicked")
         window = self.get_root()
+        # Force GDK to drain any pending input-device events (e.g. a USB
+        # mouse that was just unplugged) before we create a new window
+        # whose touch events will be delivered against GDK's device
+        # list. Skipping this caused a reproducible SIGSEGV after USB
+        # unplug + first tap on a target.
+        display = window.get_display()
+        if display is not None:
+            display.sync()
         # Hold a reference so the window can't be GC'd while live;
         # without this, the Python wrapper can be collected between
         # user taps and pending signals fire on freed state (SIGSEGV).

--- a/src/manualtest.py
+++ b/src/manualtest.py
@@ -576,15 +576,28 @@ class TouchscreenTest(Gtk.Window):
         quit_btn.connect("clicked", self._on_quit)
         overlay.add_overlay(quit_btn)
 
-        # Create touch target buttons
+        # Create touch target widgets. We use Gtk.Box + an explicit
+        # Gtk.GestureClick rather than Gtk.Button+"clicked" because
+        # Gtk.Button has internal pointer-tracking gestures that have
+        # been observed to SIGSEGV when a touch event arrives after a
+        # USB pointer device was unplugged (stale device pointer in the
+        # button's internal click controller).
         self._targets = []
         for i, (_fx, _fy) in enumerate(self.TARGET_POSITIONS):
-            btn = Gtk.Button()
-            btn.add_css_class("touch-target")
-            btn.set_size_request(self.TARGET_SIZE, self.TARGET_SIZE)
-            btn.connect("clicked", self._on_target_clicked, i)
-            self._fixed.put(btn, 0, 0)
-            self._targets.append(btn)
+            target = Gtk.Box()
+            target.add_css_class("touch-target")
+            target.set_size_request(self.TARGET_SIZE, self.TARGET_SIZE)
+            gesture = Gtk.GestureClick()
+            gesture.set_touch_only(False)
+            gesture.connect(
+                "pressed",
+                lambda g, n, x, y, idx=i, t=target: self._on_target_clicked(
+                    t, idx
+                ),
+            )
+            target.add_controller(gesture)
+            self._fixed.put(target, 0, 0)
+            self._targets.append(target)
 
         self._touched = [False] * len(self.TARGET_POSITIONS)
 

--- a/src/manualtest.py
+++ b/src/manualtest.py
@@ -388,11 +388,17 @@ class ManualTest(Adw.Bin):
     def on_touchscreen_clicked(self, button):
         print("ManualTest:on_touchscreen_clicked")
         window = self.get_root()
-        test = TouchscreenTest(window, self._on_touchscreen_test_complete)
-        test.present()
+        # Hold a reference so the window can't be GC'd while live;
+        # without this, the Python wrapper can be collected between
+        # user taps and pending signals fire on freed state (SIGSEGV).
+        self._touchscreen_test = TouchscreenTest(
+            window, self._on_touchscreen_test_complete
+        )
+        self._touchscreen_test.present()
 
     def _on_touchscreen_test_complete(self, passed):
         self.touchscreen_button.set_active(passed)
+        self._touchscreen_test = None
 
     # Make battery row clickable
     def on_battery_row_activated(self, row):
@@ -506,6 +512,7 @@ class TouchscreenTest(Gtk.Window):
         super().__init__()
         self._callback = callback
         self._reposition_source_id = None
+        self._finish_source_id = None
         self.set_decorated(False)
 
         # Load CSS for target styling
@@ -616,10 +623,11 @@ class TouchscreenTest(Gtk.Window):
             return
         self._touched[index] = True
         button.add_css_class("touched")
-        if all(self._touched):
-            GLib.timeout_add(300, self._finish_passed)
+        if all(self._touched) and self._finish_source_id is None:
+            self._finish_source_id = GLib.timeout_add(300, self._finish_passed)
 
     def _finish_passed(self):
+        self._finish_source_id = None
         self._callback(True)
         self.close()
         return False
@@ -632,4 +640,7 @@ class TouchscreenTest(Gtk.Window):
         if self._reposition_source_id is not None:
             GLib.source_remove(self._reposition_source_id)
             self._reposition_source_id = None
+        if self._finish_source_id is not None:
+            GLib.source_remove(self._finish_source_id)
+            self._finish_source_id = None
         return False

--- a/src/manualtest.py
+++ b/src/manualtest.py
@@ -576,28 +576,27 @@ class TouchscreenTest(Gtk.Window):
         quit_btn.connect("clicked", self._on_quit)
         overlay.add_overlay(quit_btn)
 
-        # Create touch target widgets. We use Gtk.Box + an explicit
-        # Gtk.GestureClick rather than Gtk.Button+"clicked" because
-        # Gtk.Button has internal pointer-tracking gestures that have
-        # been observed to SIGSEGV when a touch event arrives after a
-        # USB pointer device was unplugged (stale device pointer in the
-        # button's internal click controller).
+        # Create touch target widgets. They are passive Gtk.Box widgets
+        # with no gesture controllers of their own. Touch events on
+        # per-child gestures inside a Gtk.Fixed have been observed to
+        # SIGSEGV after a USB pointer device is unplugged (GDK's touch
+        # event routing hits stale state). Instead, install ONE gesture
+        # on the Fixed container and do our own hit-testing — this
+        # mirrors how Gtk.Overlay handles events for its children, and
+        # Overlay-hosted widgets (the Quit button) never crashed under
+        # the same conditions.
         self._targets = []
         for i, (_fx, _fy) in enumerate(self.TARGET_POSITIONS):
             target = Gtk.Box()
             target.add_css_class("touch-target")
             target.set_size_request(self.TARGET_SIZE, self.TARGET_SIZE)
-            gesture = Gtk.GestureClick()
-            gesture.set_touch_only(False)
-            gesture.connect(
-                "pressed",
-                lambda g, n, x, y, idx=i, t=target: self._on_target_clicked(
-                    t, idx
-                ),
-            )
-            target.add_controller(gesture)
             self._fixed.put(target, 0, 0)
             self._targets.append(target)
+
+        fixed_gesture = Gtk.GestureClick()
+        fixed_gesture.set_touch_only(False)
+        fixed_gesture.connect("pressed", self._on_fixed_pressed)
+        self._fixed.add_controller(fixed_gesture)
 
         self._touched = [False] * len(self.TARGET_POSITIONS)
 
@@ -651,6 +650,19 @@ class TouchscreenTest(Gtk.Window):
         for i, (x, y) in enumerate(coordinates):
             self._fixed.move(self._targets[i], x, y)
         return False
+
+    def _on_fixed_pressed(self, gesture, n_press, x, y):
+        # Manual hit-test against target rectangles. We use the stored
+        # coordinates rather than the live widget bounds because the
+        # latter requires a render pass that may not have happened yet.
+        width = self._fixed.get_width()
+        height = self._fixed.get_height()
+        coordinates = self._calculate_target_coordinates(width, height)
+        size = TouchscreenTest.TARGET_SIZE
+        for i, (tx, ty) in enumerate(coordinates):
+            if tx <= x < tx + size and ty <= y < ty + size:
+                self._on_target_clicked(self._targets[i], i)
+                return
 
     def _on_target_clicked(self, button, index):
         if self._touched[index]:

--- a/src/manualtest.py
+++ b/src/manualtest.py
@@ -387,26 +387,54 @@ class ManualTest(Adw.Bin):
     # Launch the fullscreen touchscreen test
     def on_touchscreen_clicked(self, button):
         print("ManualTest:on_touchscreen_clicked")
-        window = self.get_root()
-        # Force GDK to drain any pending input-device events (e.g. a USB
-        # mouse that was just unplugged) before we create a new window
-        # whose touch events will be delivered against GDK's device
-        # list. Skipping this caused a reproducible SIGSEGV after USB
-        # unplug + first tap on a target.
-        display = window.get_display()
-        if display is not None:
-            display.sync()
-        # Hold a reference so the window can't be GC'd while live;
-        # without this, the Python wrapper can be collected between
-        # user taps and pending signals fire on freed state (SIGSEGV).
-        self._touchscreen_test = TouchscreenTest(
-            window, self._on_touchscreen_test_complete
-        )
-        self._touchscreen_test.present()
+        # The touchscreen test runs in a subprocess. Touch event delivery
+        # in GTK/GDK has been observed to SIGSEGV after a USB pointer
+        # device is unplugged; isolating the test in its own process
+        # means such a crash only fails the test rather than killing the
+        # provisioning app.
+        import os
+        import subprocess
+        import sys
+        import threading
 
-    def _on_touchscreen_test_complete(self, passed):
+        button.set_sensitive(False)
+        self.touchscreen_button.set_sensitive(False)
+
+        runner = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "touchscreen_test_runner.py",
+        )
+
+        def _run():
+            try:
+                result = subprocess.run(
+                    [sys.executable, runner],
+                    capture_output=True,
+                    text=True,
+                    timeout=600,
+                )
+                if result.returncode != 0:
+                    print(
+                        f"Touchscreen test subprocess exited rc={result.returncode}"
+                    )
+                    if result.stderr:
+                        print(result.stderr)
+                    passed = False
+                else:
+                    passed = result.stdout.strip().endswith("pass")
+            except Exception as exc:
+                print(f"Touchscreen test subprocess error: {exc}")
+                passed = False
+            GLib.idle_add(self._on_touchscreen_test_complete, passed, button)
+
+        threading.Thread(target=_run, daemon=True).start()
+
+    def _on_touchscreen_test_complete(self, passed, click_button=None):
         self.touchscreen_button.set_active(passed)
-        self._touchscreen_test = None
+        self.touchscreen_button.set_sensitive(True)
+        if click_button is not None:
+            click_button.set_sensitive(True)
+        return False
 
     # Make battery row clickable
     def on_battery_row_activated(self, row):
@@ -497,196 +525,3 @@ class ManualTest(Adw.Bin):
         print("ManualTest:on_shown")
         self.check_status()
 
-
-class TouchscreenTest(Gtk.Window):
-    """Fullscreen white window with 8 touch targets that must all be tapped to pass."""
-
-    # Target positions as fractions of (width, height).
-    # 4 near corners, 4 closer to the middle.
-    TARGET_POSITIONS = [
-        (0.08, 0.08),  # top-left corner
-        (0.92, 0.08),  # top-right corner
-        (0.08, 0.92),  # bottom-left corner
-        (0.92, 0.92),  # bottom-right corner
-        (0.30, 0.30),  # inner top-left
-        (0.70, 0.30),  # inner top-right
-        (0.30, 0.70),  # inner bottom-left
-        (0.70, 0.70),  # inner bottom-right
-    ]
-    TARGET_SIZE = 60  # diameter of each touch target
-    REPOSITION_DELAY_MS = 16
-
-    # Track which displays already have our CSS provider registered, so
-    # we don't accumulate one per TouchscreenTest instance.
-    _css_registered_displays = set()
-
-    def __init__(self, parent, callback):
-        super().__init__()
-        self._callback = callback
-        self._reposition_source_id = None
-        self._finish_source_id = None
-        self.set_decorated(False)
-
-        # Load CSS for target styling. Register the provider on the
-        # display only once per process; re-registering on every test
-        # accumulates providers and keeps stale references alive.
-        display = parent.get_display()
-        display_id = id(display)
-        if display_id not in TouchscreenTest._css_registered_displays:
-            css = Gtk.CssProvider()
-            css.load_from_string(
-                "window.touchscreen-test { background-color: white; }"
-                ".touchscreen-instructions { color: #1f1f1f; font-size: 22px; "
-                "font-weight: bold; }"
-                ".touch-target { background: #4d4d4d; border-radius: 50%; "
-                "min-width: 60px; min-height: 60px; border: none; padding: 0; }"
-                ".touch-target.touched { background: #33cc33; }"
-            )
-            Gtk.StyleContext.add_provider_for_display(
-                display, css, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
-            )
-            TouchscreenTest._css_registered_displays.add(display_id)
-
-        self.add_css_class("touchscreen-test")
-
-        self._fixed = Gtk.Fixed()
-        self._fixed.set_hexpand(True)
-        self._fixed.set_vexpand(True)
-
-        overlay = Gtk.Overlay()
-        overlay.set_child(self._fixed)
-        self.set_child(overlay)
-
-        instructions = Gtk.Label(
-            label="Touch every spot with your finger until all spots are green to pass the test."
-        )
-        instructions.add_css_class("touchscreen-instructions")
-        instructions.set_halign(Gtk.Align.CENTER)
-        instructions.set_valign(Gtk.Align.START)
-        instructions.set_margin_top(18)
-        overlay.add_overlay(instructions)
-
-        # Quit button in top-right so user can exit with mouse/touchpad
-        quit_btn = Gtk.Button(label="Quit")
-        quit_btn.add_css_class("destructive-action")
-        quit_btn.set_halign(Gtk.Align.END)
-        quit_btn.set_valign(Gtk.Align.START)
-        quit_btn.set_margin_top(12)
-        quit_btn.set_margin_end(12)
-        quit_btn.connect("clicked", self._on_quit)
-        overlay.add_overlay(quit_btn)
-
-        # Create touch target widgets. They are passive Gtk.Box widgets
-        # with no gesture controllers of their own. Touch events on
-        # per-child gestures inside a Gtk.Fixed have been observed to
-        # SIGSEGV after a USB pointer device is unplugged (GDK's touch
-        # event routing hits stale state). Instead, install ONE gesture
-        # on the Fixed container and do our own hit-testing — this
-        # mirrors how Gtk.Overlay handles events for its children, and
-        # Overlay-hosted widgets (the Quit button) never crashed under
-        # the same conditions.
-        self._targets = []
-        for i, (_fx, _fy) in enumerate(self.TARGET_POSITIONS):
-            target = Gtk.Box()
-            target.add_css_class("touch-target")
-            target.set_size_request(self.TARGET_SIZE, self.TARGET_SIZE)
-            self._fixed.put(target, 0, 0)
-            self._targets.append(target)
-
-        fixed_gesture = Gtk.GestureClick()
-        fixed_gesture.set_touch_only(False)
-        fixed_gesture.connect("pressed", self._on_fixed_pressed)
-        self._fixed.add_controller(fixed_gesture)
-
-        self._touched = [False] * len(self.TARGET_POSITIONS)
-
-        self._fixed.connect("notify::width", self._on_layout_changed)
-        self._fixed.connect("notify::height", self._on_layout_changed)
-        self.connect("map", self._on_map)
-        self.connect("close-request", self._on_close_request)
-
-    def _on_map(self, widget):
-        # Defer fullscreen until after map: if a USB input device was
-        # just removed, GDK's device list needs time to settle before a
-        # pointer grab. Calling fullscreen() from __init__ can SIGSEGV
-        # in that window.
-        self.fullscreen()
-        self._queue_reposition_targets()
-
-    def _on_layout_changed(self, *args):
-        self._queue_reposition_targets()
-
-    def _queue_reposition_targets(self):
-        if self._reposition_source_id is not None:
-            return
-        self._reposition_source_id = GLib.timeout_add(
-            self.REPOSITION_DELAY_MS, self._reposition_targets
-        )
-
-    @staticmethod
-    def _calculate_target_coordinates(width, height):
-        if width <= 1 or height <= 1:
-            return []
-
-        half = TouchscreenTest.TARGET_SIZE // 2
-        max_x = max(0, width - TouchscreenTest.TARGET_SIZE)
-        max_y = max(0, height - TouchscreenTest.TARGET_SIZE)
-        coordinates = []
-        for fx, fy in TouchscreenTest.TARGET_POSITIONS:
-            x = max(0, min(int(fx * width) - half, max_x))
-            y = max(0, min(int(fy * height) - half, max_y))
-            coordinates.append((x, y))
-        return coordinates
-
-    def _reposition_targets(self, *args):
-        self._reposition_source_id = None
-        width = self._fixed.get_width()
-        height = self._fixed.get_height()
-        coordinates = self._calculate_target_coordinates(width, height)
-        if not coordinates:
-            self._queue_reposition_targets()
-            return False
-
-        for i, (x, y) in enumerate(coordinates):
-            self._fixed.move(self._targets[i], x, y)
-        return False
-
-    def _on_fixed_pressed(self, gesture, n_press, x, y):
-        # Manual hit-test against target rectangles. We use the stored
-        # coordinates rather than the live widget bounds because the
-        # latter requires a render pass that may not have happened yet.
-        width = self._fixed.get_width()
-        height = self._fixed.get_height()
-        coordinates = self._calculate_target_coordinates(width, height)
-        size = TouchscreenTest.TARGET_SIZE
-        for i, (tx, ty) in enumerate(coordinates):
-            if tx <= x < tx + size and ty <= y < ty + size:
-                self._on_target_clicked(self._targets[i], i)
-                return
-
-    def _on_target_clicked(self, button, index):
-        if self._touched[index]:
-            return
-        self._touched[index] = True
-        button.add_css_class("touched")
-        if all(self._touched) and self._finish_source_id is None:
-            self._finish_source_id = GLib.timeout_add(300, self._finish_passed)
-
-    def _finish_passed(self):
-        self._finish_source_id = None
-        self._callback(True)
-        self.close()
-        return False
-
-    def _on_quit(self, button):
-        self._callback(False)
-        self.close()
-
-    def _on_close_request(self, *args):
-        if self._reposition_source_id is not None:
-            GLib.source_remove(self._reposition_source_id)
-            self._reposition_source_id = None
-        if self._finish_source_id is not None:
-            GLib.source_remove(self._finish_source_id)
-            self._finish_source_id = None
-        return False

--- a/src/meson.build
+++ b/src/meson.build
@@ -76,6 +76,7 @@ sources = [
   'speccomplete.py',
   'specinfo.py',
   'sysinfo.py',
+  'touchscreen_test_runner.py',
   'secureerase.py',
   'utils.py',
   'getlearngive.png',

--- a/src/touchscreen_test_runner.py
+++ b/src/touchscreen_test_runner.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Standalone touchscreen test runner.
+
+Run as a subprocess by the manual test page so a SIGSEGV inside GTK/GDK
+touch event handling (reproducible after USB device unplug) cannot
+take down the main provisioning app. Writes a single line to stdout:
+"pass" or "fail", then exits.
+"""
+
+import sys
+
+import gi
+
+gi.require_version("Adw", "1")
+gi.require_version("Gtk", "4.0")
+from gi.repository import Adw, Gdk, GLib, Gtk
+
+
+class TouchscreenTest(Gtk.ApplicationWindow):
+    """Fullscreen white window with 8 touch targets that must all be tapped to pass."""
+
+    TARGET_POSITIONS = [
+        (0.08, 0.08),
+        (0.92, 0.08),
+        (0.08, 0.92),
+        (0.92, 0.92),
+        (0.30, 0.30),
+        (0.70, 0.30),
+        (0.30, 0.70),
+        (0.70, 0.70),
+    ]
+    TARGET_SIZE = 60
+    REPOSITION_DELAY_MS = 16
+
+    def __init__(self, app, on_complete):
+        super().__init__(application=app)
+        self._on_complete = on_complete
+        self._reposition_source_id = None
+        self._finish_source_id = None
+        self.set_decorated(False)
+
+        css = Gtk.CssProvider()
+        css.load_from_string(
+            "window.touchscreen-test { background-color: white; }"
+            ".touchscreen-instructions { color: #1f1f1f; font-size: 22px; "
+            "font-weight: bold; }"
+            ".touch-target { background: #4d4d4d; border-radius: 50%; "
+            "min-width: 60px; min-height: 60px; border: none; padding: 0; }"
+            ".touch-target.touched { background: #33cc33; }"
+        )
+        Gtk.StyleContext.add_provider_for_display(
+            Gdk.Display.get_default(),
+            css,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+        )
+
+        self.add_css_class("touchscreen-test")
+
+        self._fixed = Gtk.Fixed()
+        self._fixed.set_hexpand(True)
+        self._fixed.set_vexpand(True)
+
+        overlay = Gtk.Overlay()
+        overlay.set_child(self._fixed)
+        self.set_child(overlay)
+
+        instructions = Gtk.Label(
+            label="Touch every spot with your finger until all spots are green to pass the test."
+        )
+        instructions.add_css_class("touchscreen-instructions")
+        instructions.set_halign(Gtk.Align.CENTER)
+        instructions.set_valign(Gtk.Align.START)
+        instructions.set_margin_top(18)
+        overlay.add_overlay(instructions)
+
+        quit_btn = Gtk.Button(label="Quit")
+        quit_btn.add_css_class("destructive-action")
+        quit_btn.set_halign(Gtk.Align.END)
+        quit_btn.set_valign(Gtk.Align.START)
+        quit_btn.set_margin_top(12)
+        quit_btn.set_margin_end(12)
+        quit_btn.connect("clicked", self._on_quit)
+        overlay.add_overlay(quit_btn)
+
+        self._targets = []
+        for i, (_fx, _fy) in enumerate(self.TARGET_POSITIONS):
+            target = Gtk.Box()
+            target.add_css_class("touch-target")
+            target.set_size_request(self.TARGET_SIZE, self.TARGET_SIZE)
+            self._fixed.put(target, 0, 0)
+            self._targets.append(target)
+
+        fixed_gesture = Gtk.GestureClick()
+        fixed_gesture.set_touch_only(False)
+        fixed_gesture.connect("pressed", self._on_fixed_pressed)
+        self._fixed.add_controller(fixed_gesture)
+
+        self._touched = [False] * len(self.TARGET_POSITIONS)
+
+        self._fixed.connect("notify::width", self._on_layout_changed)
+        self._fixed.connect("notify::height", self._on_layout_changed)
+        self.connect("map", self._on_map)
+        self.connect("close-request", self._on_close_request)
+
+    def _on_map(self, widget):
+        self.fullscreen()
+        self._queue_reposition_targets()
+
+    def _on_layout_changed(self, *args):
+        self._queue_reposition_targets()
+
+    def _queue_reposition_targets(self):
+        if self._reposition_source_id is not None:
+            return
+        self._reposition_source_id = GLib.timeout_add(
+            self.REPOSITION_DELAY_MS, self._reposition_targets
+        )
+
+    @staticmethod
+    def _calculate_target_coordinates(width, height):
+        if width <= 1 or height <= 1:
+            return []
+        half = TouchscreenTest.TARGET_SIZE // 2
+        max_x = max(0, width - TouchscreenTest.TARGET_SIZE)
+        max_y = max(0, height - TouchscreenTest.TARGET_SIZE)
+        coordinates = []
+        for fx, fy in TouchscreenTest.TARGET_POSITIONS:
+            x = max(0, min(int(fx * width) - half, max_x))
+            y = max(0, min(int(fy * height) - half, max_y))
+            coordinates.append((x, y))
+        return coordinates
+
+    def _reposition_targets(self, *args):
+        self._reposition_source_id = None
+        width = self._fixed.get_width()
+        height = self._fixed.get_height()
+        coordinates = self._calculate_target_coordinates(width, height)
+        if not coordinates:
+            self._queue_reposition_targets()
+            return False
+        for i, (x, y) in enumerate(coordinates):
+            self._fixed.move(self._targets[i], x, y)
+        return False
+
+    def _on_fixed_pressed(self, gesture, n_press, x, y):
+        width = self._fixed.get_width()
+        height = self._fixed.get_height()
+        coordinates = self._calculate_target_coordinates(width, height)
+        size = TouchscreenTest.TARGET_SIZE
+        for i, (tx, ty) in enumerate(coordinates):
+            if tx <= x < tx + size and ty <= y < ty + size:
+                self._on_target_pressed(self._targets[i], i)
+                return
+
+    def _on_target_pressed(self, target, index):
+        if self._touched[index]:
+            return
+        self._touched[index] = True
+        target.add_css_class("touched")
+        if all(self._touched) and self._finish_source_id is None:
+            self._finish_source_id = GLib.timeout_add(300, self._finish_passed)
+
+    def _finish_passed(self):
+        self._finish_source_id = None
+        self._on_complete(True)
+        self.close()
+        return False
+
+    def _on_quit(self, button):
+        self._on_complete(False)
+        self.close()
+
+    def _on_close_request(self, *args):
+        if self._reposition_source_id is not None:
+            GLib.source_remove(self._reposition_source_id)
+            self._reposition_source_id = None
+        if self._finish_source_id is not None:
+            GLib.source_remove(self._finish_source_id)
+            self._finish_source_id = None
+        return False
+
+
+class _App(Adw.Application):
+    def __init__(self):
+        super().__init__(application_id="org.kramden.touchscreen-test")
+        Adw.init()
+        style_manager = Adw.StyleManager.get_default()
+        style_manager.set_color_scheme(Adw.ColorScheme.PREFER_DARK)
+        self._result = "fail"
+
+    def do_activate(self):
+        win = TouchscreenTest(self, self._on_complete)
+        win.present()
+
+    def _on_complete(self, passed):
+        self._result = "pass" if passed else "fail"
+        self.quit()
+
+
+def main():
+    app = _App()
+    app.run([])
+    sys.stdout.write(app._result + "\n")
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Original symptom: SIGSEGV crash on the touchscreen test, reported via apport, with no Python traceback. Reproducible on at least two paths.
- After several in-process workarounds, the final fix runs the touchscreen test in a **subprocess** so GTK/GDK crashes can no longer take down the provisioning app.

## Two distinct bugs were addressed

**Bug 1 — Python-side GC race** (commit `f397398`)
`on_touchscreen_clicked` constructed `TouchscreenTest`, called `present()`, and dropped the only Python reference. With no `set_transient_for`/`add_window`, the Python wrapper could be GC'd between user taps; pending GTK signals then fired on freed state. Fix: hold a parent-side reference and cancel the pending `_finish_passed` timeout on close.

**Bug 2 — GDK touch-event SIGSEGV after USB unplug**
Reproducible: unplug a USB mouse, open the touchscreen test, tap a target → crash. Tried in order:
- `f397398` Hold reference (above).
- `21f91ed` Defer `self.fullscreen()` to the map handler; register CSS provider once per process instead of per instance.
- `78c64f2` `Gdk.Display.sync()` before opening the test window to flush device-removed events.
- `a977ad8` Replace target `Gtk.Button` + `clicked` with `Gtk.Box` + explicit `Gtk.GestureClick` (Quit button never crashed, only targets did).
- `e3798c4` Single click gesture on the `Gtk.Fixed` container with manual hit-testing (mirroring Overlay-style event routing).
- All five still crashed on the touch path specifically (touchpad clicks worked).
- `ac80e19` **Final fix:** extract `TouchscreenTest` into `src/touchscreen_test_runner.py` and invoke via `subprocess.run` from a background thread. Runner writes `pass`/`fail` to stdout. A SIGSEGV in the subprocess now fails the test instead of killing the app.

## Files
- `src/manualtest.py` — Bug 1 fix, then refactored to spawn subprocess. In-process `TouchscreenTest` class removed.
- `src/touchscreen_test_runner.py` — new standalone runner.
- `src/meson.build` — installs the runner.

## Test plan
- [ ] Open touchscreen test, tap all 8 targets → checkbox set to passed.
- [ ] Open touchscreen test, hit Quit → checkbox set to failed.
- [ ] Unplug a USB mouse, then open touchscreen test, then tap a target. If the subprocess crashes, the main app must keep running and the test must register as failed.
- [ ] Run the full spec flow start-to-finish (the previous GC race repro). Navigate to manual test → run all tests except touchscreen → go back → run touchscreen. Should no longer crash.
- [ ] Confirm subprocess runner can be launched directly: `python3 src/touchscreen_test_runner.py` — should pop up the test window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)