### PR TITLE
fix: dynamically resize window to fit spec-info page content

### DIFF
--- a/src/sortly_register.py
+++ b/src/sortly_register.py
@@ -80,13 +80,8 @@ class SortlyRegister(Adw.Bin):
         self.status_label.set_wrap(True)
 
         # System info list box
-        scrolled_window = Gtk.ScrolledWindow()
-        scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
-        scrolled_window.set_vexpand(True)
-
         self.info_list_box = Gtk.ListBox()
         self.info_list_box.set_selection_mode(Gtk.SelectionMode.NONE)
-        scrolled_window.set_child(self.info_list_box)
 
         # Register button
         self.register_button = Gtk.Button(label="Update")
@@ -97,7 +92,7 @@ class SortlyRegister(Adw.Bin):
 
         vbox.append(knumber_box)
         vbox.append(self.status_label)
-        vbox.append(scrolled_window)
+        vbox.append(self.info_list_box)
         vbox.append(self.register_button)
 
         self.set_child(vbox)

--- a/src/spec.py
+++ b/src/spec.py
@@ -20,14 +20,7 @@ class WizardWindow(Gtk.ApplicationWindow):
         super().__init__(application=app, title="Kramden - Spec")
 
         self.set_icon_name("kramden")
-        self.set_default_size(800, 800)
-        display = Gdk.Display.get_default()
-        if display:
-            monitors = display.get_monitors()
-            if monitors.get_n_items() > 0:
-                self._apply_monitor_size(monitors.get_item(0))
-            else:
-                monitors.connect("items-changed", self._on_monitors_changed)
+        self.set_default_size(800, -1)
 
         # Initialize the observable property for tracking state
         self.observable_property = ObservableProperty(
@@ -85,7 +78,7 @@ class WizardWindow(Gtk.ApplicationWindow):
         self.stack.add_named(self.page3, "page3")
         self.stack.add_named(self.page4, "page4")
 
-        self.stack.set_vexpand(True)  # Ensure the stack expands vertically
+        self.stack.set_vhomogeneous(False)
 
         # Content Box
         content_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
@@ -114,22 +107,13 @@ class WizardWindow(Gtk.ApplicationWindow):
         # Fake visible change to set state info
         self.page1.on_shown()
 
-    def _apply_monitor_size(self, monitor):
-        geo = monitor.get_geometry()
-        self.set_default_size(
-            min(800, int(geo.width * 0.8)),
-            min(800, int(geo.height * 0.8)),
-        )
-
-    def _on_monitors_changed(self, monitors, position, removed, added):
-        if monitors.get_n_items() > 0:
-            self._apply_monitor_size(monitors.get_item(0))
 
     def on_visible_page_changed(self, stack, params):
         print("on_visible_page_changed")
         current = stack.get_visible_child()
         self.title_widget.set_label(current.title)
         current.on_shown()
+        self.set_default_size(800, 500)
 
     def on_prev_clicked(self, button=None):
         if self.current_page > 0:

--- a/src/specinfo.py
+++ b/src/specinfo.py
@@ -44,10 +44,6 @@ class SpecInfo(Adw.Bin):
         # Create a box to hold the content
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
 
-        # Create scrollable window
-        scrolled_window = Gtk.ScrolledWindow()
-        scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
-
         # Create a list box to hold the rows
         list_box = Gtk.ListBox()
         list_box.set_selection_mode(Gtk.SelectionMode.NONE)
@@ -159,8 +155,7 @@ class SpecInfo(Adw.Bin):
 
         vbox.append(self._loading_box)
         vbox.append(list_box)
-        scrolled_window.set_child(vbox)
-        self.set_child(scrolled_window)
+        self.set_child(vbox)
 
     def on_shown(self):
         if self._gather_in_progress:


### PR DESCRIPTION
Remove ScrolledWindow wrappers from SpecInfo and SortlyRegister so the window height is driven directly by content. Set vhomogeneous=False on the ViewStack so each page reports its own natural height. Reset the default height to 500 on every page transition so the window shrinks when navigating to a shorter page, with 500px as the minimum.