### PR TITLE
feat: show loading spinner on Click Here buttons while app is running

### DIFF
--- a/src/manualtest.py
+++ b/src/manualtest.py
@@ -429,12 +429,13 @@ class ManualTest(Adw.Bin):
                 proc = subprocess.Popen(
                     command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
                 )
-                proc.wait()
-            except Exception:
-                pass
+                proc.communicate()
+            except Exception as e:
+                print(f"_launch_app_with_spinner: failed to launch '{command}': {e}")
             GLib.idle_add(_restore)
 
         def _restore():
+            spinner.stop()
             button.set_label("Click Here")
             button.set_sensitive(True)
             return False
@@ -491,6 +492,9 @@ class ManualTest(Adw.Bin):
         self.touchscreen_button.set_active(passed)
         self.touchscreen_button.set_sensitive(True)
         if click_button is not None:
+            child = click_button.get_child()
+            if isinstance(child, Gtk.Spinner):
+                child.stop()
             click_button.set_label("Click Here")
             click_button.set_sensitive(True)
         return False

--- a/src/manualtest.py
+++ b/src/manualtest.py
@@ -1,4 +1,6 @@
 import gi
+import subprocess
+import threading
 
 gi.require_version("Adw", "1")
 gi.require_version("Gdk", "4.0")
@@ -416,6 +418,29 @@ class ManualTest(Adw.Bin):
         print(d)
         self.check_status()
 
+    def _launch_app_with_spinner(self, button, command):
+        spinner = Gtk.Spinner()
+        spinner.start()
+        button.set_child(spinner)
+        button.set_sensitive(False)
+
+        def _run():
+            try:
+                proc = subprocess.Popen(
+                    command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                )
+                proc.wait()
+            except Exception:
+                pass
+            GLib.idle_add(_restore)
+
+        def _restore():
+            button.set_label("Click Here")
+            button.set_sensitive(True)
+            return False
+
+        threading.Thread(target=_run, daemon=True).start()
+
     # Launch the fullscreen touchscreen test
     def on_touchscreen_clicked(self, button):
         print("ManualTest:on_touchscreen_clicked")
@@ -425,10 +450,11 @@ class ManualTest(Adw.Bin):
         # means such a crash only fails the test rather than killing the
         # provisioning app.
         import os
-        import subprocess
         import sys
-        import threading
 
+        spinner = Gtk.Spinner()
+        spinner.start()
+        button.set_child(spinner)
         button.set_sensitive(False)
         self.touchscreen_button.set_sensitive(False)
 
@@ -465,6 +491,7 @@ class ManualTest(Adw.Bin):
         self.touchscreen_button.set_active(passed)
         self.touchscreen_button.set_sensitive(True)
         if click_button is not None:
+            click_button.set_label("Click Here")
             click_button.set_sensitive(True)
         return False
 
@@ -492,7 +519,7 @@ class ManualTest(Adw.Bin):
     # Launch the screen-test app when clicked
     def on_screentest_clicked(self, button):
         print("ManualTest:on_screentest_clicked")
-        self.utils.launch_app("screen-test")
+        self._launch_app_with_spinner(button, "screen-test")
 
     # Launch the gnome-text-editor app when clicked
     def on_keyboard_clicked(self, button):
@@ -503,11 +530,14 @@ class ManualTest(Adw.Bin):
     def on_webcam_clicked(self, button):
         print("ManualTest:on_webcam_clicked")
         if self.utils.file_exists_and_executable("/usr/bin/guvcview"):
-            self.utils.launch_app("guvcview")
+            cmd = "guvcview"
         elif self.utils.file_exists_and_executable("/usr/bin/cheese"):
-            self.utils.launch_app("cheese")
+            cmd = "cheese"
         elif self.utils.file_exists_and_executable("/usr/bin/snapshot"):
-            self.utils.launch_app("snapshot")
+            cmd = "snapshot"
+        else:
+            return
+        self._launch_app_with_spinner(button, cmd)
 
     # Handle toggled event for the browser button
     def on_browser_toggled(self, button):
@@ -519,7 +549,7 @@ class ManualTest(Adw.Bin):
     # Launch the xdg-open app to open https://vimeo.com/116979416 in browser
     def on_browser_clicked(self, button):
         print("Manual:on_browser_clicked")
-        self.utils.launch_app("xdg-open https://vimeo.com/116979416")
+        self._launch_app_with_spinner(button, "xdg-open https://vimeo.com/116979416")
 
     def check_status(self):
         print("ManualTest:check_status")


### PR DESCRIPTION
This pull request refactors how external applications are launched from the UI in `src/manualtest.py`. The main improvement is the introduction of a new method to launch apps with a loading spinner and proper button state management, which enhances user feedback and code maintainability. Several button click handlers are updated to use this new approach.

**Refactoring and UI Improvements:**

* Introduced a new `_launch_app_with_spinner` method that launches external applications in a background thread, displays a `Gtk.Spinner` on the button, and disables the button until the process completes. This provides clear feedback to the user and prevents duplicate clicks.
* Updated the `on_screentest_clicked`, `on_webcam_clicked`, and `on_browser_clicked` methods to use `_launch_app_with_spinner` instead of directly launching apps, ensuring consistent UI behavior across these actions. [[1]](diffhunk://#diff-d28a8e9bae39f5ad574e27b0a254db0f44552645577023b8707ad3d42b9a47a2L495-R522) [[2]](diffhunk://#diff-d28a8e9bae39f5ad574e27b0a254db0f44552645577023b8707ad3d42b9a47a2L506-R540) [[3]](diffhunk://#diff-d28a8e9bae39f5ad574e27b0a254db0f44552645577023b8707ad3d42b9a47a2L522-R552)

**Code Cleanup:**

* Removed redundant imports of `subprocess` and `threading` from within functions, consolidating them at the top of the file. [[1]](diffhunk://#diff-d28a8e9bae39f5ad574e27b0a254db0f44552645577023b8707ad3d42b9a47a2R2-R3) [[2]](diffhunk://#diff-d28a8e9bae39f5ad574e27b0a254db0f44552645577023b8707ad3d42b9a47a2L428-R457)
* Improved button state restoration by resetting the label and enabling the button after the launched application exits.