### PR TITLE
fix: show no internet message when Sortly is unreachable

### DIFF
--- a/src/knum.py
+++ b/src/knum.py
@@ -14,6 +14,7 @@ from sortly import (
     search_item_by_name,
     update_item,
     get_system_info,
+    sortly_error_message,
 )
 
 
@@ -135,7 +136,7 @@ class KramdenNumber(Adw.Bin):
             )
             results = search_by_serial(api_key, folder_ids, serial)
         except Exception as e:
-            GLib.idle_add(self._on_lookup_complete, None, str(e))
+            GLib.idle_add(self._on_lookup_complete, None, sortly_error_message(e))
             return
         GLib.idle_add(self._on_lookup_complete, results, None)
 
@@ -262,7 +263,7 @@ class KramdenNumber(Adw.Bin):
 
             GLib.idle_add(self._on_register_complete, True, knumber)
         except Exception as e:
-            GLib.idle_add(self._on_register_complete, False, str(e))
+            GLib.idle_add(self._on_register_complete, False, sortly_error_message(e))
 
     def _on_register_complete(self, success, result):
         self.spinner.stop()

--- a/src/sortly.py
+++ b/src/sortly.py
@@ -135,6 +135,13 @@ def _sortly_request(method, url, **kwargs):
     return response
 
 
+def sortly_error_message(exc):
+    """Return a user-friendly error message for a Sortly-related exception."""
+    if isinstance(exc, requests.ConnectionError):
+        return "No internet connection. Cannot access Sortly."
+    return str(exc)
+
+
 def get_stage_folder_ids(stage):
     """Return folder IDs for the given stage, or TEST_FOLDER_IDS if KRAMDEN_TEST is set."""
     if os.environ.get("KRAMDEN_TEST"):
@@ -204,6 +211,8 @@ def search_by_serial(api_key, folder_ids, serial_number):
                     more_pages = False
 
         except Exception as e:
+            if isinstance(e, requests.ConnectionError):
+                raise
             print(f"Error: {e}")
             break
 
@@ -272,6 +281,8 @@ def search_item_by_name(api_key, folder_ids, item_name):
         return exact_matches
 
     except (requests.RequestException, ValueError) as e:
+        if isinstance(e, requests.ConnectionError):
+            raise
         print(f"Error searching for item: {e}")
         return []
 
@@ -449,6 +460,8 @@ def list_subfolders(api_key, parent_id, depth=0):
                 break
 
             except (requests.RequestException, ValueError) as e:
+                if isinstance(e, requests.ConnectionError):
+                    raise
                 print(f"{indent}Error listing subfolders: {e}")
                 more_pages = False
                 break

--- a/src/sortly_register.py
+++ b/src/sortly_register.py
@@ -18,6 +18,7 @@ from sortly import (
     create_item,
     update_item,
     get_system_info,
+    sortly_error_message,
 )
 
 
@@ -155,7 +156,7 @@ class SortlyRegister(Adw.Bin):
             )
             results = search_by_serial(api_key, folder_ids, serial)
         except Exception as e:
-            GLib.idle_add(self._on_lookup_complete, None, str(e))
+            GLib.idle_add(self._on_lookup_complete, None, sortly_error_message(e))
             return
         GLib.idle_add(self._on_lookup_complete, results, None)
 
@@ -272,7 +273,7 @@ class SortlyRegister(Adw.Bin):
                 self._folder_ids = folder_ids
             results = search_item_by_name(api_key, folder_ids, knumber)
         except Exception as e:
-            GLib.idle_add(self._on_search_complete, None, knumber, str(e))
+            GLib.idle_add(self._on_search_complete, None, knumber, sortly_error_message(e))
             return
         GLib.idle_add(self._on_search_complete, results, knumber, None)
 
@@ -343,7 +344,7 @@ class SortlyRegister(Adw.Bin):
             )
             results = search_item_by_name(api_key, folder_ids, knumber)
         except Exception as e:
-            GLib.idle_add(self._on_search_complete, None, knumber, str(e))
+            GLib.idle_add(self._on_search_complete, None, knumber, sortly_error_message(e))
             return
         GLib.idle_add(self._on_search_complete, results, knumber, None)
 
@@ -413,7 +414,7 @@ class SortlyRegister(Adw.Bin):
 
             GLib.idle_add(self._on_register_complete, True, None)
         except Exception as e:
-            GLib.idle_add(self._on_register_complete, False, str(e))
+            GLib.idle_add(self._on_register_complete, False, sortly_error_message(e))
 
     def _on_register_complete(self, success, error):
         self.spinner.stop()


### PR DESCRIPTION
## Summary

- `list_subfolders`, `search_by_serial`, and `search_item_by_name` were swallowing `requests.ConnectionError` internally and returning empty results, causing the UI to display "No record found" when the real issue was no network connectivity
- Added `sortly_error_message()` helper to `sortly.py` that maps `ConnectionError` to a human-readable "No internet connection. Cannot access Sortly." message
- Re-raise `ConnectionError` from the three Sortly functions so it propagates to the thread exception handlers in `sortly_register.py` and `knum.py`

Fixes #121

## Test plan

- [ ] With no internet connection (ethernet/WiFi disconnected), open Spec and attempt a Sortly search — should show "No internet connection. Cannot access Sortly." instead of "No record found for K-..."
- [ ] With internet connected, confirm normal search behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)