### PR TITLE
feat: fullscreen screen-section picker, SpecInfo hard-block, charging…

### DIFF
--- a/src/manualtest_v3.py
+++ b/src/manualtest_v3.py
@@ -39,7 +39,7 @@ PHYSICAL_SCREEN_SECTION_TYPES = {"Screen Cracked"}
 # Ask which part is affected, then where on that part (same sextant grid as
 # SCREEN_SECTIONS below -- see _build_section_picker).
 PHYSICAL_PART_LOCATION_TYPES = {"Dents", "Deep Scratches", "Peeling Paint", "Cracks"}
-PHYSICAL_AFFECTED_PARTS = ["Keyboard", "Case", "Screen", "Bezel", "Touchpad"]
+PHYSICAL_AFFECTED_PARTS = ["Near Keyboard", "Top", "Bottom", "Bezel"]
 # Ask which port type, reusing the same location/port-# picker as the
 # dedicated USB-A/USB-C pages (see UsbPortLocationMixin). Only USB-A/USB-C
 # trigger the suppress-on-matching-page logic below since those are the only
@@ -176,31 +176,10 @@ WEBCAM_DEFECT_TYPES = [
     "Everything is black and white and flashing",
 ]
 
-# These two webcam reasons have a common fix that's worth ruling out before
-# reporting them as a real defect -- see WebcamPage.build_reason_locations/
-# _build_webcam_confirm.
-WEBCAM_SOLID_BLACK_REASON = WEBCAM_DEFECT_TYPES[0]
-WEBCAM_FLASHING_REASON = WEBCAM_DEFECT_TYPES[4]
-
-WEBCAM_COVER_CHECK_PROMPT = (
-    "Please check along the top of the screen or near the webcam for a "
-    "small lever or switch. There is likely a built in cover blocking the "
-    "webcams view. Did this fix the issue?"
-)
-WEBCAM_WRONG_CAMERA_PROMPT = (
-    "The webcam the device is choosing by default may be the incorrect "
-    "one (instructions). If you need assistance, please ask a staff "
-    "member or Super Geek. Did this fix the issue?"
-)
-WEBCAM_IR_CHOICE_PROMPT = (
-    "Which of these best describes what a staff member or Super Geek confirmed?"
-)
-WEBCAM_IR_PRESENT_LABEL = (
-    "A staff member or Super Geek confirmed only an IR camera is present"
-)
-WEBCAM_IR_WORKS_LABEL = "A staff member or Super Geek confirmed only the IR camera works"
-WEBCAM_IR_PRESENT_NOTE = "Only IR camera present"
-WEBCAM_IR_WORKS_NOTE = "Webcam broken, Infrared camera works"
+# Tracking-sheet note text used when WebcamPage auto-detects no usable
+# webcam is present -- see WebcamPage.__init__/get_notes_entries.
+WEBCAM_NO_DEVICE_NOTE = "No webcam present"
+WEBCAM_IR_ONLY_NOTE = "IR camera only, no webcam present"
 
 TOUCHSCREEN_DEFECT_TYPES = [
     "Touchscreen doesn't work",
@@ -444,14 +423,29 @@ def _build_toggle_button_grid(title, options, on_toggle, columns=3):
 
 
 def _build_section_picker(
-    owner, entry_row, data=None, options=None, title="Location", select_all_label=None
+    owner,
+    entry_row,
+    data=None,
+    options=None,
+    title="Location",
+    select_all_label=None,
+    fullscreen=False,
 ):
-    """Embed a "click the affected section(s)" picker directly into
-    `entry_row` (no popup window) and keep `data["selected"]` in sync as
-    the tech clicks buttons. Shared by ScreenPage, TouchscreenPage,
-    TouchpadPage, the generic default location picker, and Physical
-    Defects' "Screen Cracked"/dents-scratches-etc pickers. `owner` just
-    needs check_status(), called once a selection changes."""
+    """Embed a "click the affected section(s)" picker into `entry_row` and
+    keep `data["selected"]` in sync as the tech makes a selection. Shared by
+    ScreenPage, TouchscreenPage, TouchpadPage, the generic default location
+    picker, and Physical Defects' "Screen Cracked"/dents-scratches-etc
+    pickers. `owner` just needs check_status(), called once a selection
+    changes.
+
+    `fullscreen=True` is for the call sites that are genuinely about
+    pointing at the physical screen (ScreenSectionMixin, Physical Defects'
+    "Screen Cracked") -- there the picker launches a fullscreen
+    click-through window (screen_section_picker_runner.py) over the 6
+    screen sections (see SCREEN_SECTIONS) instead of a small button grid.
+    Everything else (touchpad zones, port locations, the generic
+    default/custom-defect fallback) isn't a screen location, so it keeps
+    the original embedded button-grid picker regardless of `options`."""
     options = options or SCREEN_SECTIONS
     if data is None:
         data = {"type": "sections", "selected": []}
@@ -460,11 +454,99 @@ def _build_section_picker(
         data["selected"] = selected
         owner.check_status()
 
-    list_row = _build_section_row(
-        title, options, select_all_label=select_all_label, on_change=_on_change
-    )
+    if fullscreen:
+        list_row = _build_fullscreen_section_row(
+            title, select_all_label, data, on_change=_on_change
+        )
+    else:
+        list_row = _build_section_row(
+            title, options, select_all_label=select_all_label, on_change=_on_change
+        )
     entry_row.add_row(list_row)
     return data
+
+
+def _build_fullscreen_section_row(title, select_all_label, data, on_change=None):
+    """Build the Gtk.ListBoxRow used by the default (screen-section)
+    _build_section_picker case: a title, a status label showing the
+    currently selected section(s), and a button that launches the
+    fullscreen click-through picker in screen_section_picker_runner.py.
+    `on_change` is called with the list of currently selected sections (in
+    SCREEN_SECTIONS order) once the picker window closes."""
+    row_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+    row_box.set_margin_top(8)
+    row_box.set_margin_bottom(8)
+    row_box.set_margin_start(12)
+    row_box.set_margin_end(12)
+
+    title_label = Gtk.Label(label=title)
+    title_label.set_halign(Gtk.Align.START)
+    title_label.add_css_class("dim-label")
+    row_box.append(title_label)
+
+    status_label = Gtk.Label(label="No section selected yet.")
+    status_label.set_halign(Gtk.Align.START)
+    status_label.set_wrap(True)
+    row_box.append(status_label)
+
+    def _update_status():
+        selected = data.get("selected") or []
+        status_label.set_label(", ".join(selected) if selected else "No section selected yet.")
+
+    _update_status()
+
+    launch_button = Gtk.Button(label="Mark Location on Screen")
+    launch_button.set_halign(Gtk.Align.START)
+
+    def _on_launch_clicked(button):
+        button.set_sensitive(False)
+        runner = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)),
+            "screen_section_picker_runner.py",
+        )
+        cmd = [sys.executable, runner, "--heading", title]
+        if select_all_label:
+            cmd += ["--select-all-label", select_all_label]
+        initial = data.get("selected") or []
+        if initial:
+            cmd += ["--initial", ",".join(initial)]
+
+        def _run():
+            try:
+                result = subprocess.run(
+                    cmd, capture_output=True, text=True, timeout=600
+                )
+                if result.returncode != 0:
+                    print(f"Section picker subprocess exited rc={result.returncode}")
+                    if result.stderr:
+                        print(result.stderr)
+                    selected = data.get("selected") or []
+                else:
+                    line = result.stdout.strip()
+                    selected = [s for s in line.split(",") if s] if line else []
+            except Exception as exc:
+                print(f"Section picker subprocess error: {exc}")
+                selected = data.get("selected") or []
+            GLib.idle_add(_on_picker_done, selected, button)
+
+        threading.Thread(target=_run, daemon=True).start()
+
+    def _on_picker_done(selected, button):
+        data["selected"] = selected
+        _update_status()
+        if on_change:
+            on_change(selected)
+        button.set_sensitive(True)
+        return False
+
+    launch_button.connect("clicked", _on_launch_clicked)
+    row_box.append(launch_button)
+
+    list_row = Gtk.ListBoxRow()
+    list_row.set_selectable(False)
+    list_row.set_activatable(False)
+    list_row.set_child(row_box)
+    return list_row
 
 
 def _set_status(label, text, is_error=False, auto_clear_ms=None):
@@ -1118,6 +1200,16 @@ class PhysicalDefectsPage(Adw.Bin):
         header.set_halign(Gtk.Align.START)
         vbox.append(header)
 
+        # Shown when the device appears to be charging only through a
+        # secondary port (e.g. USB-C) rather than its primary barrel/DC-jack
+        # port -- see _update_charging_port_banner.
+        self.charging_port_banner = Adw.Banner()
+        self.charging_port_banner.set_button_label("Re-check")
+        self.charging_port_banner.connect(
+            "button-clicked", self._on_charging_port_recheck_clicked
+        )
+        vbox.append(self.charging_port_banner)
+
         instructions_label = Gtk.Label(
             label="Please inspect the machine for any physical damage. Make "
             "sure to check the top, sides."
@@ -1308,6 +1400,7 @@ class PhysicalDefectsPage(Adw.Bin):
                 entry_row,
                 title="Location of crack",
                 select_all_label="Entire Screen",
+                fullscreen=True,
             )
 
         if defect_type in PHYSICAL_PART_LOCATION_TYPES:
@@ -1513,7 +1606,9 @@ class PhysicalDefectsPage(Adw.Bin):
                 # double-reported there too.
                 page = self._usb_page_for_type(port_type)
                 if page is not None and port_type not in data["_suppressed_pages"]:
-                    page.suppress_reason_option(self._port_damage_reason_for_type(port_type))
+                    page.suppress_reason_option(
+                        self._port_damage_reason_for_type(port_type)
+                    )
                     data["_suppressed_pages"][port_type] = page
 
         def _on_types_change(selected):
@@ -1727,6 +1822,24 @@ class PhysicalDefectsPage(Adw.Bin):
 
     def on_shown(self):
         self.check_status()
+        self._update_charging_port_banner()
+
+    def _on_charging_port_recheck_clicked(self, banner):
+        self._update_charging_port_banner()
+
+    def _update_charging_port_banner(self):
+        if Utils.primary_charging_port_unused():
+            self.charging_port_banner.set_title(
+                "This device appears to be charging through a secondary "
+                "port (e.g. USB-C) rather than its primary charging port. "
+                "If the primary charging port is damaged, report it below "
+                'under "Port Damaged" -> "Charging Port". '
+                "Otherwise, please plug the charger into the primary port "
+                "and use that instead."
+            )
+            self.charging_port_banner.set_revealed(True)
+        else:
+            self.charging_port_banner.set_revealed(False)
 
 
 class WiFiPage(TogglePage):
@@ -1819,12 +1932,30 @@ class TouchpadPage(TogglePage):
             selected = data.get("selected") or []
             behaviors = [TOUCHPAD_CURSOR_NOTES[opt] for opt in selected]
             suffix = f": {', '.join(behaviors)}" if behaviors else ""
-            return [f"{code} {TOUCHPAD_CURSOR_LABEL}{suffix}"]
+            addendum = ""
+            if "Cursor moves on its own" in selected:
+                addendum = self._cursor_moves_addendum()
+            return [f"{code} {TOUCHPAD_CURSOR_LABEL}{suffix}{addendum}"]
         if reason in TOUCHPAD_REASON_NOTES:
             return [f"{code} {TOUCHPAD_REASON_NOTES[reason]}"]
         # Custom free-text reason -- fall back to the generic coded label
         # (already includes a code, e.g. "TPO: some custom text").
         return [self._reason_label(reason)]
+
+    @staticmethod
+    def _cursor_moves_addendum():
+        """"Cursor moves on its own" can be a symptom of a trackpoint or
+        touchscreen sending stray input rather than an actual touchpad
+        defect -- flag that possibility on the tracking sheet when either
+        is present, so the diagnosis isn't pinned solely on the touchpad."""
+        culprits = []
+        if Utils.has_trackpoint():
+            culprits.append("trackpoint")
+        if Utils.has_touchscreen():
+            culprits.append("touchscreen")
+        if not culprits:
+            return ""
+        return f" (May be a {' or '.join(culprits)} issue)"
 
 
 class ScreenSectionMixin:
@@ -1844,6 +1975,7 @@ class ScreenSectionMixin:
             entry_row,
             title="Location on screen",
             select_all_label="Entire Screen",
+            fullscreen=True,
         )
 
 
@@ -1969,6 +2101,15 @@ class WebcamPage(TogglePage):
             ),
         )
         self.utils = Utils()
+        # Detected once at startup, since webcam hardware presence doesn't
+        # change during a session -- "present"/"ir_only"/"absent". Anything
+        # other than "present" auto-skips this page (see WizardWindow's use
+        # of page.skip in spec_v3.py) and reports the hardware situation
+        # instead of running the test -- see get_result/get_notes_entries.
+        self.webcam_status = Utils.get_webcam_status()
+        self.skip = self.webcam_status != "present"
+        if self.webcam_status != "present":
+            self.passed = True
 
     def build_action(self, box):
         launch_row = Adw.ActionRow()
@@ -2019,198 +2160,20 @@ class WebcamPage(TogglePage):
             )
 
     def build_reason_locations(self, entry_row, reason):
-        if reason == WEBCAM_SOLID_BLACK_REASON:
-            return self._build_webcam_confirm(entry_row, WEBCAM_COVER_CHECK_PROMPT)
-        if reason == WEBCAM_FLASHING_REASON:
-            return self._build_webcam_confirm(
-                entry_row,
-                WEBCAM_WRONG_CAMERA_PROMPT,
-                build_followup=self._build_ir_choice_content,
-            )
+        # No webcam defect has a meaningful location to narrow down.
         return {"type": "none"}
 
-    def _build_webcam_confirm(self, entry_row, prompt, build_followup=None):
-        """Common "did this fix it?" row for the two webcam reasons that
-        have a known non-defect cause (a physical lens cover, or the wrong
-        camera being selected by default) -- see WEBCAM_SOLID_BLACK_REASON/
-        WEBCAM_FLASHING_REASON. "Yes" means it wasn't a real defect at all
-        (see get_notes_entries/_failed_codes, which drop it from the
-        tracking sheet); "No" reports it as a defect, or -- for the
-        flashing reason -- reveals a further IR-camera choice
-        (build_followup). Yes/No stay toggleable (not locked in after the
-        first click) so the tech can freely change their answer."""
-        data = {
-            "type": "webcam_confirm",
-            "resolved": None,
-            "needs_ir_choice": build_followup is not None,
-            "ir_resolution": None,
-        }
-
-        row = Adw.ActionRow(title=prompt)
-        row.set_title_lines(0)
-
-        button_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
-        button_box.add_css_class("linked")
-        yes_button = Gtk.ToggleButton(label="Yes")
-        no_button = Gtk.ToggleButton(label="No")
-        yes_button.set_valign(Gtk.Align.CENTER)
-        no_button.set_valign(Gtk.Align.CENTER)
-        button_box.append(yes_button)
-        button_box.append(no_button)
-        row.add_suffix(button_box)
-        entry_row.add_row(row)
-
-        followup_revealer = None
-        if build_followup is not None:
-            followup_revealer = Gtk.Revealer()
-            followup_revealer.set_transition_type(Gtk.RevealerTransitionType.SLIDE_DOWN)
-            followup_row = Gtk.ListBoxRow()
-            followup_row.set_selectable(False)
-            followup_row.set_activatable(False)
-            followup_row.set_child(build_followup(data))
-            followup_revealer.set_child(followup_row)
-            followup_revealer.set_reveal_child(False)
-            entry_row.add_row(followup_revealer)
-
-        def _sync(resolved):
-            data["resolved"] = resolved
-            if followup_revealer is not None:
-                followup_revealer.set_reveal_child(resolved is False)
-            self.check_status()
-
-        def _on_yes_toggled(button):
-            if button.get_active():
-                no_button.set_active(False)
-                button.add_css_class("toggle-pass-active")
-                _sync(True)
-            else:
-                button.remove_css_class("toggle-pass-active")
-                if not no_button.get_active():
-                    _sync(None)
-
-        def _on_no_toggled(button):
-            if button.get_active():
-                yes_button.set_active(False)
-                button.add_css_class("toggle-fail-active")
-                _sync(False)
-            else:
-                button.remove_css_class("toggle-fail-active")
-                if not yes_button.get_active():
-                    _sync(None)
-
-        yes_button.connect("toggled", _on_yes_toggled)
-        no_button.connect("toggled", _on_no_toggled)
-
-        return data
-
-    def _build_ir_choice_content(self, data):
-        """Follow-up content revealed when the wrong-camera fix didn't
-        resolve the flashing reason -- a staff member/Super Geek must
-        physically confirm which IR-camera situation applies (see
-        WEBCAM_IR_PRESENT_LABEL/WEBCAM_IR_WORKS_LABEL). Stays toggleable,
-        same as the Yes/No question above."""
-        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
-
-        prompt_label = Gtk.Label(label=WEBCAM_IR_CHOICE_PROMPT)
-        prompt_label.set_wrap(True)
-        prompt_label.set_justify(Gtk.Justification.CENTER)
-        prompt_label.set_halign(Gtk.Align.CENTER)
-        content.append(prompt_label)
-
-        present_button = self._build_wrapped_toggle_button(WEBCAM_IR_PRESENT_LABEL)
-        works_button = self._build_wrapped_toggle_button(WEBCAM_IR_WORKS_LABEL)
-        content.append(present_button)
-        content.append(works_button)
-
-        def _on_present_toggled(button):
-            if button.get_active():
-                works_button.set_active(False)
-                button.add_css_class("toggle-fail-active")
-                data["ir_resolution"] = "ir_present"
-            else:
-                button.remove_css_class("toggle-fail-active")
-                if not works_button.get_active():
-                    data["ir_resolution"] = None
-            self.check_status()
-
-        def _on_works_toggled(button):
-            if button.get_active():
-                present_button.set_active(False)
-                button.add_css_class("toggle-fail-active")
-                data["ir_resolution"] = "ir_works"
-            else:
-                button.remove_css_class("toggle-fail-active")
-                if not present_button.get_active():
-                    data["ir_resolution"] = None
-            self.check_status()
-
-        present_button.connect("toggled", _on_present_toggled)
-        works_button.connect("toggled", _on_works_toggled)
-
-        return content
-
-    def _build_wrapped_toggle_button(self, text):
-        button = Gtk.ToggleButton()
-        label = Gtk.Label(label=text)
-        label.set_wrap(True)
-        label.set_justify(Gtk.Justification.CENTER)
-        button.set_child(label)
-        return button
-
-    def _reason_is_filled(self, data):
-        if data.get("type") == "webcam_confirm":
-            resolved = data.get("resolved")
-            if resolved is None:
-                return False
-            if resolved or not data.get("needs_ir_choice"):
-                return True
-            return data.get("ir_resolution") is not None
-        return super()._reason_is_filled(data)
-
-    def _failed_codes(self):
-        """Overrides TogglePage._failed_codes -- a webcam_confirm reason
-        answered "Yes" (fixed by the lens cover/camera selection, not a
-        real defect) is dropped from the failure-code summary, same as
-        get_notes_entries drops it from the tracking sheet."""
-        codes = set()
-        for reason, (_, data) in self._reason_entries.items():
-            if data.get("type") == "webcam_confirm" and data.get("resolved"):
-                continue
-            code = self._reason_code(reason)
-            if code:
-                codes.add(code)
-        return sorted(codes, key=self._code_sort_key)
+    def get_result(self):
+        if self.webcam_status != "present":
+            return "N/A"
+        return super().get_result()
 
     def get_notes_entries(self):
-        """Overrides TogglePage.get_notes_entries -- a webcam_confirm
-        reason resolved as "Yes" isn't a real defect and is omitted
-        entirely (see _build_webcam_confirm); the flashing reason's IR
-        follow-up gets its own plain-English wording (WEBCAM_IR_PRESENT_NOTE/
-        WEBCAM_IR_WORKS_NOTE)."""
-        if self.passed is not False:
-            return []
-        if not self._reason_entries:
-            return [{"text": "Webcam: issue reported"}]
-        details = []
-        for reason, data in self._sorted_reason_items():
-            details.extend(self._webcam_reason_notes(reason, data))
-        if not details:
-            return []
-        return [{"text": ", ".join(details)}]
-
-    def _webcam_reason_notes(self, reason, data):
-        if data.get("type") != "webcam_confirm":
-            return [self._reason_label(reason)]
-        if data.get("resolved"):
-            return []
-        code = self._reason_code(reason)
-        if data.get("needs_ir_choice"):
-            resolution = data.get("ir_resolution")
-            if resolution == "ir_present":
-                return [f"{code}: {WEBCAM_IR_PRESENT_NOTE}"]
-            if resolution == "ir_works":
-                return [f"{code}: {WEBCAM_IR_WORKS_NOTE}"]
-        return [self._reason_label(reason)]
+        if self.webcam_status == "absent":
+            return [{"text": WEBCAM_NO_DEVICE_NOTE}]
+        if self.webcam_status == "ir_only":
+            return [{"text": WEBCAM_IR_ONLY_NOTE}]
+        return super().get_notes_entries()
 
 
 class UsbPortLocationMixin:
@@ -2424,8 +2387,9 @@ class KeyboardPage(TogglePage):
             code_prefix="KB",
             instructions=(
                 "Type the sample text below using every key listed at least once, "
-                "as well as Backspace, Period, and Enter, to confirm each key "
-                "registers correctly. "
+                "as well as Backspace, Period, Shift, and Enter, to confirm each key "
+                "registers correctly. All keys should respond accurately and "
+                "with a normal amount of effort."
             ),
         )
 
@@ -2443,11 +2407,10 @@ class KeyboardPage(TogglePage):
         self.period_pressed = False
         self.backspace_pressed = False
         self.enter_pressed = False
+        self.shift_pressed = False
         self._all_chars_typed = False
         self._no_issues_auto_triggered = False
         self.original_text = "The quick brown fox jumps over the lazy dog 1234567890"
-
-        template_group = Adw.PreferencesGroup()
 
         self.keyboard_template_buffer = Gtk.TextBuffer()
         self.keyboard_template_buffer.set_text(self.original_text)
@@ -2463,7 +2426,7 @@ class KeyboardPage(TogglePage):
         self.keyboard_template.add_css_class("transparent-textview")
 
         self.green_tag = self.keyboard_template_buffer.create_tag(
-            "green", foreground="green", weight=700
+            "green", foreground="#3fe35a", weight=700
         )
         self.gray_tag = self.keyboard_template_buffer.create_tag(
             "gray", foreground="#c0c0c0"
@@ -2471,6 +2434,11 @@ class KeyboardPage(TogglePage):
 
         self.ever_typed_chars = set()
         self.ever_typed_chars_lower = set()
+
+        self.shift_label = Gtk.Label(label="Shift")
+        self.shift_label.add_css_class("keyboard-key")
+        self.shift_label.set_valign(Gtk.Align.CENTER)
+        self.shift_label.set_margin_end(6)
 
         self.period_label = Gtk.Label(label="Period")
         self.period_label.add_css_class("keyboard-key")
@@ -2489,26 +2457,43 @@ class KeyboardPage(TogglePage):
 
         template_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
         template_row.append(self.keyboard_template)
+        template_row.append(self.shift_label)
         template_row.append(self.period_label)
         template_row.append(self.backspace_label)
         template_row.append(self.enter_label)
         box.append(template_row)
 
-        self.keyboard_entry_row = Adw.EntryRow()
-        self.keyboard_entry_row.set_title("Type here:")
-        self.keyboard_entry_row.connect("changed", self._on_keyboard_changed)
-        _text = self.keyboard_entry_row.get_delegate()
-        if _text is not None:
-            _text.connect(
-                "paste-clipboard",
-                lambda w: GObject.signal_stop_emission_by_name(w, "paste-clipboard"),
-            )
+        input_label = Gtk.Label(label="Type here:")
+        input_label.set_xalign(0)
+        input_label.add_css_class("dim-label")
+        box.append(input_label)
+
+        self.keyboard_input_buffer = Gtk.TextBuffer()
+        self.keyboard_input_buffer.connect("changed", self._on_keyboard_changed)
+
+        self.keyboard_input_view = Gtk.TextView(buffer=self.keyboard_input_buffer)
+        self.keyboard_input_view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        self.keyboard_input_view.set_top_margin(8)
+        self.keyboard_input_view.set_bottom_margin(8)
+        self.keyboard_input_view.set_left_margin(8)
+        self.keyboard_input_view.set_right_margin(8)
+        self.keyboard_input_view.connect(
+            "paste-clipboard",
+            lambda w: GObject.signal_stop_emission_by_name(w, "paste-clipboard"),
+        )
         _key_ctrl = Gtk.EventControllerKey()
         _key_ctrl.set_propagation_phase(Gtk.PropagationPhase.CAPTURE)
         _key_ctrl.connect("key-pressed", self._on_keyboard_key_pressed)
-        self.keyboard_entry_row.add_controller(_key_ctrl)
-        template_group.add(self.keyboard_entry_row)
-        box.append(template_group)
+        self.keyboard_input_view.add_controller(_key_ctrl)
+
+        input_scroller = Gtk.ScrolledWindow()
+        input_scroller.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        input_scroller.set_min_content_height(80)
+        input_scroller.set_child(self.keyboard_input_view)
+
+        input_frame = Gtk.Frame()
+        input_frame.set_child(input_scroller)
+        box.append(input_frame)
 
         self.update_text_highlighting("")
 
@@ -2522,11 +2507,16 @@ class KeyboardPage(TogglePage):
         elif keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter):
             self.enter_label.add_css_class("keyboard-key-passed")
             self.enter_pressed = True
+        elif keyval in (Gdk.KEY_Shift_L, Gdk.KEY_Shift_R):
+            self.shift_label.add_css_class("keyboard-key-passed")
+            self.shift_pressed = True
         self._check_typing_test_complete()
         return False
 
-    def _on_keyboard_changed(self, entry_row):
-        self.update_text_highlighting(entry_row.get_text())
+    def _on_keyboard_changed(self, buffer):
+        start = buffer.get_start_iter()
+        end = buffer.get_end_iter()
+        self.update_text_highlighting(buffer.get_text(start, end, False))
 
     def update_text_highlighting(self, typed_text):
         self.ever_typed_chars.update(typed_text)
@@ -2542,10 +2532,7 @@ class KeyboardPage(TogglePage):
             start_iter = self.keyboard_template_buffer.get_iter_at_offset(index)
             end_iter = self.keyboard_template_buffer.get_iter_at_offset(index + 1)
 
-            if index == 0:
-                matched = char in self.ever_typed_chars
-            else:
-                matched = char.lower() in self.ever_typed_chars_lower
+            matched = char.lower() in self.ever_typed_chars_lower
 
             if matched:
                 self.keyboard_template_buffer.apply_tag(
@@ -2562,7 +2549,7 @@ class KeyboardPage(TogglePage):
 
     def _check_typing_test_complete(self):
         """Every listed key must be typed at least once, plus Period,
-        Backspace, and Enter each pressed at least once, before the
+        Backspace, Shift, and Enter each pressed at least once, before the
         keyboard test counts as complete. "No" is only ever auto-selected
         the first time this becomes true -- if the tech has since clicked
         "Yes", further key presses must not silently flip it back to
@@ -2572,6 +2559,7 @@ class KeyboardPage(TogglePage):
             and self.period_pressed
             and self.backspace_pressed
             and self.enter_pressed
+            and self.shift_pressed
         ):
             return
         self.typing_test_complete = True

--- a/src/screen_section_picker_runner.py
+++ b/src/screen_section_picker_runner.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Standalone fullscreen "click the affected screen section(s)" picker.
+
+Run as a subprocess by the manual test page (see _build_section_picker in
+manualtest_v3.py) so the tech can point directly at the physical screen --
+which is split into a 2x3 grid of sections -- instead of picking from a
+small button grid embedded in the app. Prints the selected section
+name(s), comma-separated (may be empty), on a single line to stdout, then
+exits. Kept standalone (no import of manualtest_v3.py) to match
+touchscreen_test_runner.py; SECTIONS below must be kept in sync with
+SCREEN_SECTIONS there.
+"""
+
+import argparse
+import sys
+
+import gi
+
+gi.require_version("Adw", "1")
+gi.require_version("Gtk", "4.0")
+from gi.repository import Adw, Gdk, Gtk
+
+SECTIONS = [
+    "Upper Left",
+    "Upper Middle",
+    "Upper Right",
+    "Lower Left",
+    "Lower Middle",
+    "Lower Right",
+]
+
+
+class SectionPicker(Gtk.ApplicationWindow):
+    """Fullscreen plain-white window split into a bordered 2x3 grid. Clicking
+    a cell toggles it as selected (border/text turn green) and a Submit
+    button in the top right finishes the picker, reporting every currently
+    selected section."""
+
+    def __init__(self, app, on_complete, heading, select_all_label, initial_selected):
+        super().__init__(application=app)
+        self._on_complete = on_complete
+        self.set_decorated(False)
+
+        css = Gtk.CssProvider()
+        css.load_from_string(
+            "window.section-picker { background-color: white; }"
+            ".section-picker-heading { color: #1f1f1f; font-size: 20px; "
+            "font-weight: bold; }"
+            ".section-cell { background-color: white; border: 3px solid "
+            "#808080; border-radius: 0; color: #1f1f1f; font-size: 22px; "
+            "font-weight: bold; }"
+            ".section-cell.selected { border: 5px solid #3fe35a; "
+            "color: #3fe35a; background-color: rgba(63, 227, 90, 0.12); }"
+        )
+        Gtk.StyleContext.add_provider_for_display(
+            Gdk.Display.get_default(),
+            css,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+        )
+        self.add_css_class("section-picker")
+
+        outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+
+        top_bar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        top_bar.set_margin_top(12)
+        top_bar.set_margin_bottom(6)
+        top_bar.set_margin_start(12)
+        top_bar.set_margin_end(12)
+
+        heading_label = Gtk.Label(label=heading)
+        heading_label.add_css_class("section-picker-heading")
+        heading_label.set_hexpand(True)
+        heading_label.set_halign(Gtk.Align.START)
+        heading_label.set_wrap(True)
+        top_bar.append(heading_label)
+
+        if select_all_label:
+            select_all_button = Gtk.Button(label=select_all_label)
+            select_all_button.set_valign(Gtk.Align.CENTER)
+            select_all_button.connect("clicked", self._on_select_all)
+            top_bar.append(select_all_button)
+
+        submit_button = Gtk.Button(label="Submit")
+        submit_button.add_css_class("suggested-action")
+        submit_button.set_valign(Gtk.Align.CENTER)
+        submit_button.connect("clicked", self._on_submit)
+        top_bar.append(submit_button)
+
+        outer.append(top_bar)
+
+        grid = Gtk.Grid()
+        grid.set_hexpand(True)
+        grid.set_vexpand(True)
+        grid.set_row_homogeneous(True)
+        grid.set_column_homogeneous(True)
+        grid.set_margin_start(12)
+        grid.set_margin_end(12)
+        grid.set_margin_bottom(12)
+
+        self._buttons = {}
+        for index, section in enumerate(SECTIONS):
+            row, col = divmod(index, 3)
+            button = Gtk.ToggleButton(label=section)
+            button.add_css_class("section-cell")
+            button.set_hexpand(True)
+            button.set_vexpand(True)
+            if section in initial_selected:
+                button.set_active(True)
+                button.add_css_class("selected")
+            button.connect("toggled", self._on_section_toggled, section)
+            grid.attach(button, col, row, 1, 1)
+            self._buttons[section] = button
+
+        outer.append(grid)
+        self.set_child(outer)
+
+        key_ctrl = Gtk.EventControllerKey()
+        key_ctrl.connect("key-pressed", self._on_key_pressed)
+        self.add_controller(key_ctrl)
+
+        self.connect("map", self._on_map)
+
+    def _on_map(self, widget):
+        self.fullscreen()
+
+    def _on_section_toggled(self, button, section):
+        if button.get_active():
+            button.add_css_class("selected")
+        else:
+            button.remove_css_class("selected")
+
+    def _on_select_all(self, button):
+        for cell_button in self._buttons.values():
+            cell_button.set_active(True)
+
+    def _selected_sections(self):
+        return [s for s in SECTIONS if self._buttons[s].get_active()]
+
+    def _on_submit(self, button):
+        self._finish()
+
+    def _on_key_pressed(self, controller, keyval, keycode, state):
+        if keyval == Gdk.KEY_Escape:
+            self._finish()
+            return True
+        return False
+
+    def _finish(self):
+        self._on_complete(self._selected_sections())
+        self.close()
+
+
+class _App(Adw.Application):
+    def __init__(self, heading, select_all_label, initial_selected):
+        super().__init__(application_id="org.kramden.section-picker")
+        Adw.init()
+        Adw.StyleManager.get_default().set_color_scheme(Adw.ColorScheme.PREFER_LIGHT)
+        self._heading = heading
+        self._select_all_label = select_all_label
+        self._initial_selected = initial_selected
+        self._result = []
+
+    def do_activate(self):
+        win = SectionPicker(
+            self,
+            self._on_complete,
+            self._heading,
+            self._select_all_label,
+            self._initial_selected,
+        )
+        win.present()
+
+    def _on_complete(self, selected):
+        self._result = selected
+        self.quit()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--heading", default="Click every affected section, then press Submit."
+    )
+    parser.add_argument("--select-all-label", default="")
+    parser.add_argument("--initial", default="")
+    args = parser.parse_args()
+
+    initial_selected = {s.strip() for s in args.initial.split(",") if s.strip()}
+
+    app = _App(args.heading, args.select_all_label, initial_selected)
+    app.run([])
+    sys.stdout.write(",".join(app._result) + "\n")
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/spec_v3.py
+++ b/src/spec_v3.py
@@ -129,6 +129,7 @@ class WizardWindow(Gtk.ApplicationWindow):
         specinfo.state = self.observable_property
         specinfo.on_loading_changed = self._on_specinfo_loading_changed
         self._specinfo_loading = False
+        self.specinfo_page = specinfo
 
         for page in manual_test_pages:
             page.state = self.observable_property
@@ -222,7 +223,10 @@ class WizardWindow(Gtk.ApplicationWindow):
 
         current = self.pages[self.current_page]
         if hasattr(current, "is_complete") and not current.is_complete():
-            self._show_incomplete_warning()
+            if current is self.specinfo_page:
+                self._show_specinfo_blocked_warning()
+            else:
+                self._show_incomplete_warning()
             return
 
         self._advance_next()
@@ -243,6 +247,25 @@ class WizardWindow(Gtk.ApplicationWindow):
         dialog.close()
         if response == Gtk.ResponseType.OK:
             self._advance_next()
+
+    def _show_specinfo_blocked_warning(self):
+        dialog = Gtk.MessageDialog(
+            transient_for=self,
+            modal=True,
+            message_type=Gtk.MessageType.WARNING,
+            buttons=Gtk.ButtonsType.NONE,
+            text="There is either asset info on this device or a drive in "
+            "this device. You can not spec this device. Please find a "
+            "Super Geek or Staff member and hand the machine to them.",
+        )
+        dialog.add_button("Power Off", Gtk.ResponseType.ACCEPT)
+        dialog.connect("response", self._on_specinfo_blocked_response)
+        dialog.present()
+
+    def _on_specinfo_blocked_response(self, dialog, response):
+        dialog.close()
+        if response == Gtk.ResponseType.ACCEPT:
+            Utils.power_off()
 
     def _show_incomplete_warning(self):
         dialog = Gtk.MessageDialog(
@@ -278,9 +301,10 @@ class WizardWindow(Gtk.ApplicationWindow):
             self.next_button.set_label("Complete")
             self.next_button.add_css_class("button-next-last-page")
             self.next_button.remove_css_class("suggested-action")
-            all_complete = all(
-                page.is_complete() for page in self.manual_test_pages
-            ) and self.pages[last_index].is_complete()
+            all_complete = (
+                all(page.is_complete() for page in self.manual_test_pages)
+                and self.pages[last_index].is_complete()
+            )
             self.next_button.set_sensitive(all_complete)
         else:
             self.next_button.remove_css_class("button-next-last-page")

--- a/src/speccomplete_v3.py
+++ b/src/speccomplete_v3.py
@@ -217,7 +217,7 @@ class SpecCompleteV3(Adw.Bin):
             else:
                 manual_test_results["Sound"] = "Pass"
 
-        if self.specinfo is not None and not state.get("SpecInfo", True):
+        if self.specinfo is not None:
             notes_entries.extend(self.specinfo.get_notes_entries())
 
         self.tracking_button.set_sensitive(False)

--- a/src/specinfo.py
+++ b/src/specinfo.py
@@ -8,16 +8,10 @@ from gi.repository import Adw, GLib, Gtk
 from loading_capture import StdoutCapture
 from utils import Utils
 
-# Ordered so each reason's 1-based position is its tracking-sheet note code
-# (e.g. "SI1: BIOS password is set"). To add a new System Info check, add its
-# failure-reason string here (in get_failure_reasons() too) -- it gets the
-# next number for free; edit a string in place to change its wording.
-SPEC_INFO_REASONS = [
-    "BIOS password is set",
-    "Asset info present on device",
-    "Computrace/Absolute is active",
-    "Disk configuration needs review",
-]
+# Toggle: when True, finding a drive already installed in the device blocks
+# the SpecInfo page's Next button (until staff override it). Flip to False
+# to allow proceeding with a drive present, in case this policy changes.
+BLOCK_NEXT_WHEN_DRIVE_PRESENT = True
 
 
 class SpecInfo(Adw.Bin):
@@ -177,9 +171,7 @@ class SpecInfo(Adw.Bin):
         self._loading_textview.set_monospace(True)
         self._loading_textview.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
         loading_scroll = Gtk.ScrolledWindow()
-        loading_scroll.set_policy(
-            Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC
-        )
+        loading_scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         loading_scroll.set_min_content_height(320)
         loading_scroll.set_vexpand(True)
         loading_scroll.set_child(self._loading_textview)
@@ -328,7 +320,8 @@ class SpecInfo(Adw.Bin):
         bios_password = self._gathered["bios_password"]
         bios_password_warning = self._gathered.get("bios_password_warning")
         if bios_password and not self.bios_password_override:
-            # True: password detected – error state, blocks completion
+            # True: password detected -- flagged on the tracking sheet (see
+            # get_notes_entries) but does not block Next/completion.
             self.bios_password_row.set_subtitle("Has Password")
             self.bios_password_row.set_icon_name("emblem-important-symbolic")
             self.bios_password_row.add_css_class("text-error")
@@ -338,7 +331,6 @@ class SpecInfo(Adw.Bin):
                     "BIOS Password Override",
                     self._on_bios_password_override_accepted,
                 )
-            passed = False
         elif bios_password is None and not self.bios_password_override:
             # None: indeterminate – warning state, does NOT block completion
             self.bios_password_row.set_subtitle(
@@ -449,7 +441,7 @@ class SpecInfo(Adw.Bin):
             self.disks_populated = True
 
         # Check disk override status (runs every time on_shown is called)
-        if self.has_disks and not self.disk_override:
+        if BLOCK_NEXT_WHEN_DRIVE_PRESENT and self.has_disks and not self.disk_override:
             passed = False
 
         # Populate battery information
@@ -477,30 +469,37 @@ class SpecInfo(Adw.Bin):
         state["SpecInfo"] = passed
         print("specinfo:_render " + str(self.state.get_value()))
 
+    def is_complete(self):
+        """Whether the SpecInfo page's Next button should be enabled. A
+        drive or asset tag found on the device blocks progress outright
+        (staff can override via the row's Override button); a BIOS
+        password does not block -- see get_notes_entries()."""
+        if self._gathered.get("asset_info") and not self.asset_info_override:
+            return False
+        if BLOCK_NEXT_WHEN_DRIVE_PRESENT and self.has_disks and not self.disk_override:
+            return True
+        return True
+
     def get_failure_reasons(self):
         if not self._data_ready:
             return ["System info not yet gathered"]
         reasons = []
         if self._gathered.get("bios_password") and not self.bios_password_override:
-            reasons.append("BIOS password is set")
-        if self._gathered.get("asset_info") and not self.asset_info_override:
-            reasons.append("Asset info present on device")
+            reasons.append("HAS BIOS PASSWORD")
         if self._gathered.get("computrace") is True:
             reasons.append("Computrace/Absolute is active")
-        if self.has_disks and not self.disk_override:
-            reasons.append("Disk configuration needs review")
         return reasons
 
     def get_notes_entries(self):
-        """Same reasons as get_failure_reasons(), coded for the tracking
-        sheet's Notes & Cosmetics box (e.g. "SI1: BIOS password is set")."""
+        """Tracking-sheet notes for System Info issues that don't block
+        completion outright. A drive or asset tag blocks the SpecInfo
+        page's Next button before a tracking sheet can even be generated
+        (see is_complete()), so neither is reported here."""
         entries = []
-        for reason in self.get_failure_reasons():
-            try:
-                code = f"SI{SPEC_INFO_REASONS.index(reason) + 1}"
-            except ValueError:
-                code = "SIX"
-            entries.append({"text": f"{code}: {reason}"})
+        if self._gathered.get("bios_password") and not self.bios_password_override:
+            entries.append({"text": "<b>HAS BIOS PASSWORD</b>"})
+        if self._gathered.get("computrace") is True:
+            entries.append({"text": "Computrace/Absolute is active"})
         return entries
 
     def _add_override_button(self, parent_row, dialog_title, on_accepted):

--- a/src/specinfo.py
+++ b/src/specinfo.py
@@ -477,7 +477,7 @@ class SpecInfo(Adw.Bin):
         if self._gathered.get("asset_info") and not self.asset_info_override:
             return False
         if BLOCK_NEXT_WHEN_DRIVE_PRESENT and self.has_disks and not self.disk_override:
-            return True
+            return False
         return True
 
     def get_failure_reasons(self):

--- a/src/utils.py
+++ b/src/utils.py
@@ -1113,12 +1113,35 @@ class Utils:
         Defects page to prompt the tech to check/use the primary port
         instead."""
         status = Utils.get_charging_port_status()
-        return (
-            status["has_primary_port"]
-            and status["has_secondary_port"]
-            and status["secondary_online"]
-            and not status["primary_online"]
-        )
+        if not (status["has_primary_port"] and status["has_secondary_port"]):
+            return False
+        if not status["secondary_online"]:
+            return False
+        if status["primary_online"]:
+            return False
+
+        # Be conservative: if we can't read any primary "online" value, don't
+        # claim the primary port is unused.
+        try:
+            entries = os.listdir("/sys/class/power_supply/")
+        except OSError:
+            return False
+
+        primary_read_succeeded = False
+        for entry in entries:
+            base = f"/sys/class/power_supply/{entry}"
+            try:
+                with open(f"{base}/type", "r") as f:
+                    if f.read().strip() != "Mains":
+                        continue
+                with open(f"{base}/online", "r") as f:
+                    primary_read_succeeded = True
+                    if f.read().strip() == "1":
+                        return False
+            except OSError:
+                continue
+
+        return primary_read_succeeded
 
     KRAMDEN_EFIVAR_GUID = "9a8e2042-75d4-4d70-9890-6a8437367c1f"
     KRAMDEN_EFIVAR_PATH = (

--- a/src/utils.py
+++ b/src/utils.py
@@ -2,6 +2,7 @@ import psutil
 import subprocess
 import threading
 import os
+import glob
 import tempfile
 from constants import snap_packages, deb_packages, CHASSIS_TYPE_MAP
 import gi
@@ -127,6 +128,12 @@ class Utils:
         if result.returncode == 0:
             Utils.write_kramden_number_efivar(hostname)
         return result.returncode == 0
+
+    # Power off the machine (used when a device can't be specced and must be
+    # handed to a Super Geek/Staff member instead).
+    @staticmethod
+    def power_off():
+        subprocess.run(["systemctl", "poweroff"])
 
     # Set timezone and sync hardware clock
     def sync_clock(self):
@@ -961,6 +968,43 @@ class Utils:
         return False
 
     @staticmethod
+    def get_webcam_status():
+        """Classify camera hardware by inspecting /dev/video* device names:
+        "present" (at least one real, non-IR camera exists), "ir_only"
+        (only an infrared/Windows Hello camera exists), or "absent" (no
+        camera device at all)."""
+        ir_keywords = ["infrared", "ir camera", "windows hello", "ir sensor"]
+        found_ir = False
+        for video_path in sorted(glob.glob("/dev/video*")):
+            name_file = f"/sys/class/video4linux/{os.path.basename(video_path)}/name"
+            try:
+                with open(name_file) as f:
+                    name = f.read().strip().lower()
+            except OSError:
+                continue
+            if any(kw in name for kw in ir_keywords):
+                found_ir = True
+            else:
+                return "present"
+        return "ir_only" if found_ir else "absent"
+
+    @staticmethod
+    def has_trackpoint():
+        """Check if the system has a trackpoint (pointing stick) by
+        inspecting input device names for known trackpoint identifiers."""
+        try:
+            with open("/proc/bus/input/devices", "r") as f:
+                content = f.read()
+        except OSError as e:
+            print(f"trackpoint detection: error reading input devices: {e}")
+            return False
+        pattern = re.compile(r"trackpoint|pointstick|dualpoint stick", re.IGNORECASE)
+        for line in content.splitlines():
+            if line.startswith("N: Name=") and pattern.search(line):
+                return True
+        return False
+
+    @staticmethod
     def is_wifi_connected():
         """Whether a WiFi device currently has an active connection."""
         try:
@@ -995,6 +1039,86 @@ class Utils:
             print(f"has_usb_c: error reading /sys/class/typec/: {e}")
             return True
         return any("port" in entry for entry in entries)
+
+    @staticmethod
+    def get_charging_port_status():
+        """Inspect /sys/class/power_supply/ to tell whether this device is
+        being charged through its primary port (a "Mains"-type supply --
+        the barrel/DC-jack port on devices like Dell laptops) versus only
+        through a secondary USB charging path (e.g. a USB-C PD port also
+        present on the same device).
+
+        Returns a dict:
+          has_primary_port: a "Mains"-type power supply exists at all
+          has_secondary_port: a "USB*"-type power supply exists at all
+          primary_online: the primary port is actively delivering power
+          secondary_online: a secondary port is actively delivering power
+
+        Only counts an "online" reading when it can actually be read, so a
+        permissions/kernel quirk on one supply can't falsely report power
+        as absent -- callers should treat this as best-effort information,
+        not a guarantee.
+        """
+        has_primary_port = False
+        has_secondary_port = False
+        primary_online = False
+        secondary_online = False
+        try:
+            entries = os.listdir("/sys/class/power_supply/")
+        except OSError as e:
+            print(f"get_charging_port_status: error reading power_supply: {e}")
+            entries = []
+
+        for entry in entries:
+            base = f"/sys/class/power_supply/{entry}"
+            try:
+                with open(f"{base}/type", "r") as f:
+                    supply_type = f.read().strip()
+            except OSError:
+                continue
+
+            if supply_type == "Mains":
+                is_primary = True
+            elif supply_type.startswith("USB"):
+                is_primary = False
+            else:
+                continue
+
+            try:
+                with open(f"{base}/online", "r") as f:
+                    online = f.read().strip() == "1"
+            except OSError:
+                online = False
+
+            if is_primary:
+                has_primary_port = True
+                primary_online = primary_online or online
+            else:
+                has_secondary_port = True
+                secondary_online = secondary_online or online
+
+        return {
+            "has_primary_port": has_primary_port,
+            "has_secondary_port": has_secondary_port,
+            "primary_online": primary_online,
+            "secondary_online": secondary_online,
+        }
+
+    @staticmethod
+    def primary_charging_port_unused():
+        """True when this device has both a primary (Mains/barrel) charging
+        port and a secondary USB charging port, the secondary port is
+        currently delivering power, but the primary port is not -- i.e. the
+        machine is plugged in via the "wrong" port. Used by the Physical
+        Defects page to prompt the tech to check/use the primary port
+        instead."""
+        status = Utils.get_charging_port_status()
+        return (
+            status["has_primary_port"]
+            and status["has_secondary_port"]
+            and status["secondary_online"]
+            and not status["primary_online"]
+        )
 
     KRAMDEN_EFIVAR_GUID = "9a8e2042-75d4-4d70-9890-6a8437367c1f"
     KRAMDEN_EFIVAR_PATH = (


### PR DESCRIPTION
… port check

- Screen/touchscreen/Physical-Defects crack location picking now launches a fullscreen click-through picker (screen_section_picker_runner.py) instead of an embedded button grid.
- Simplify webcam defect flow: drop the lens-cover/wrong-camera "did this fix it" sub-flows in favor of auto-detecting webcam presence (present/ir_only/absent) at startup and reporting that directly.
- Touchpad "cursor moves on its own" now notes on the tracking sheet if a trackpoint or touchscreen is present, since either can be the real cause.
- SpecInfo page: Next is now hard-blocked when a drive or asset tag is found (toggle via BLOCK_NEXT_WHEN_DRIVE_PRESENT), with a dedicated warning dialog and a Power Off button (Utils.power_off). BIOS password no longer blocks Next but is always reported bold on the tracking sheet; asset/drive presence are no longer reported there since reaching the tracking sheet with either present is no longer possible.
- Physical Defects page: flag via a banner when the device is charging only through a secondary port (e.g. USB-C) instead of its primary barrel/DC-jack port (Utils.get_charging_port_status/ primary_charging_port_unused), prompting the tech to check for damage or use the primary port.