### PR TITLE
Spec v3 webcam fix

### DIFF
--- a/src/generate_tracking_sheet.py
+++ b/src/generate_tracking_sheet.py
@@ -366,22 +366,20 @@ def generate_tracking_sheet(
 
     # ===== Spec grid: RAM/Storage/CPU, Model/Bat0, Graphics/Bat1 =====
     batteries = system_info.get("Batteries") or {}
-    battery_names = list(batteries.keys())
 
-    def battery_cell(index):
-        if index >= len(battery_names):
-            return "", ""
-        name = battery_names[index]
+    # Bat0 is always shown explicitly: a BAT1-only machine or one with no
+    # battery at all (e.g. a desktop) should call out the missing primary
+    # battery rather than silently shifting BAT1 into the Bat0 slot.
+    bat0_label = "Bat0:"
+    bat0_value = f"{batteries['BAT0']}%" if "BAT0" in batteries else "NONE"
+
+    other_batteries = [(name, cap) for name, cap in batteries.items() if name != "BAT0"]
+    if other_batteries:
+        name, cap = other_batteries[0]
         label = "Bat" + name[3:] if name.upper().startswith("BAT") else name
-        return f"{label}:", f"{batteries[name]}%"
-
-    bat0_label, bat0_value = battery_cell(0)
-    bat1_label, bat1_value = battery_cell(1)
-
-    # No batteries at all (e.g. a desktop) is worth calling out explicitly
-    # rather than leaving the Bat0 field blank.
-    if not battery_names:
-        bat0_label, bat0_value = "Bat0:", "NONE"
+        bat1_label, bat1_value = f"{label}:", f"{cap}%"
+    else:
+        bat1_label, bat1_value = "", ""
 
     ram_value = f"{system_info.get('RAM', '')}GB"
 

--- a/src/generate_tracking_sheet_v3.py
+++ b/src/generate_tracking_sheet_v3.py
@@ -496,22 +496,20 @@ def generate_tracking_sheet(
 
     # ===== Spec grid: RAM/Storage/CPU, Model/Bat0, Graphics/Bat1 =====
     batteries = system_info.get("Batteries") or {}
-    battery_names = list(batteries.keys())
 
-    def battery_cell(index):
-        if index >= len(battery_names):
-            return "", ""
-        name = battery_names[index]
+    # Bat0 is always shown explicitly: a BAT1-only machine or one with no
+    # battery at all (e.g. a desktop) should call out the missing primary
+    # battery rather than silently shifting BAT1 into the Bat0 slot.
+    bat0_label = "Bat0:"
+    bat0_value = f"{batteries['BAT0']}%" if "BAT0" in batteries else "NONE"
+
+    other_batteries = [(name, cap) for name, cap in batteries.items() if name != "BAT0"]
+    if other_batteries:
+        name, cap = other_batteries[0]
         label = "Bat" + name[3:] if name.upper().startswith("BAT") else name
-        return f"{label}:", f"{batteries[name]}%"
-
-    bat0_label, bat0_value = battery_cell(0)
-    bat1_label, bat1_value = battery_cell(1)
-
-    # No batteries at all (e.g. a desktop) is worth calling out explicitly
-    # rather than leaving the Bat0 field blank.
-    if not battery_names:
-        bat0_label, bat0_value = "Bat0:", "NONE"
+        bat1_label, bat1_value = f"{label}:", f"{cap}%"
+    else:
+        bat1_label, bat1_value = "", ""
 
     ram_value = f"{system_info.get('RAM', '')}GB"
 
@@ -597,7 +595,7 @@ def generate_tracking_sheet(
 
     # When there's no second battery, drop the Bat1 label/value columns and
     # hand the freed width to the Graphics value column instead.
-    if len(battery_names) < 2:
+    if not bat1_value:
         graphics_row_widths = [
             spec_label_col0,
             usable_width - spec_label_col0,

--- a/src/manualtest_v3.py
+++ b/src/manualtest_v3.py
@@ -3209,7 +3209,8 @@ class UsbCPage(UsbPortLocationMixin, TogglePage):
                 "Use a provided USB-C dock and USB mouse to test each USB-C "
                 "port. Also, plug into each USB-C port upside-down and test "
                 "it that way as well. If the only USB-C port present is the "
-                "charing port, then you may select yes and move on."
+                "charging port, then you may select yes and move on. Place tape "
+                "over any defective USB-C ports and report it below."
             ),
         )
 
@@ -3333,7 +3334,7 @@ class KeyboardPage(TogglePage):
         self.shift_pressed = False
         self._all_chars_typed = False
         self._no_issues_auto_triggered = False
-        self.original_text = "The quick brown fox jumps over the lazy dog 1234567890"
+        self.original_text = "The quick brown fox jumps over the lazy dog. 1234567890"
 
         self.keyboard_template_buffer = Gtk.TextBuffer()
         self.keyboard_template_buffer.set_text(self.original_text)

--- a/src/manualtest_v3.py
+++ b/src/manualtest_v3.py
@@ -643,6 +643,25 @@ def _rebuild_port_number_rows(
         ports_box.append(port_row)
 
 
+def _build_note_row(text):
+    """Plain, non-interactive Gtk.ListBoxRow holding a wrapped label -- for
+    informational notes embedded in an expander row alongside (or instead
+    of) a location picker (see WebcamPage.build_reason_locations)."""
+    label = Gtk.Label(label=text)
+    label.set_xalign(0)
+    label.set_wrap(True)
+    label.add_css_class("dim-label")
+    label.set_margin_top(8)
+    label.set_margin_bottom(8)
+    label.set_margin_start(12)
+    label.set_margin_end(12)
+    row = Gtk.ListBoxRow()
+    row.set_selectable(False)
+    row.set_activatable(False)
+    row.set_child(label)
+    return row
+
+
 def _set_status(label, text, is_error=False, auto_clear_ms=None):
     label.set_label(text)
     if is_error:
@@ -3060,6 +3079,16 @@ class WebcamPage(TogglePage):
 
     def build_reason_locations(self, entry_row, reason):
         # No webcam defect has a meaningful location to narrow down.
+        if reason == WEBCAM_DEFECT_TYPES[1]:  # "...solid black screen"
+            # Many laptops have a physical privacy shutter over the camera
+            # lens -- easy to mistake for a dead webcam if it's slid shut.
+            entry_row.add_row(
+                _build_note_row(
+                    "Before reporting this: check for a physical camera "
+                    "cover with a moveable switch, and make sure it is "
+                    "slid open."
+                )
+            )
         return {"type": "none"}
 
     def get_result(self):

--- a/src/manualtest_v3.py
+++ b/src/manualtest_v3.py
@@ -1282,6 +1282,17 @@ class TogglePage(Adw.Bin):
             return [f"{self.title} not completed"]
         return []
 
+    def get_datacodes(self):
+        """Data codes (e.g. "KB02") this page is reporting, for the
+        machine-wide Data Codes string sent to Sortly -- see
+        SpecCompleteV3._gather_datacodes. Same codes as
+        get_failure_reasons' compact summary, just without the
+        "<title> failed:" wrapper, and empty whenever this page passed,
+        wasn't tested, or failed with no reason recorded."""
+        if self.passed is not False:
+            return []
+        return self._failed_codes()
+
     def get_notes_entries(self):
         """Each reported reason becomes its own coded detail (e.g. "KB02:
         Key(s) Sticking (F, G)"), all joined onto a single line so multiple
@@ -2514,20 +2525,15 @@ class PhysicalDefectsPage(Adw.Bin):
 
         return label
 
-    def get_failure_reasons(self):
-        """Reported defects are summarized as just their data codes (e.g.
-        "PD01, PD05") rather than the full defect/location text -- that
-        detail already lives on the tracking sheet (see get_notes_entries);
-        this is just the compact Spec Complete screen summary. "Broken
-        Part" is left out entirely when everything selected under it was
-        handed off to a dedicated test page -- see
-        _broken_part_has_own_content."""
-        if self.has_defects is None:
-            return ["Physical defects check not completed"]
-        if not self.has_defects:
+    def _failed_codes(self):
+        """Data codes (e.g. "PD01") for every reported defect, deduped and
+        sorted in numeric order -- shared by get_failure_reasons' compact
+        summary and get_datacodes' feed to the Sortly Data Codes string
+        (see SpecCompleteV3._gather_datacodes). "Broken Part" is left out
+        entirely when everything selected under it was handed off to a
+        dedicated test page -- see _broken_part_has_own_content."""
+        if not self.has_defects or not self._defect_entries:
             return []
-        if not self._defect_entries:
-            return ["Physical defects present"]
         codes = set()
         for defect_type, (entry_row, data) in self._defect_entries.items():
             if defect_type == "Broken Part" and not self._broken_part_has_own_content(
@@ -2535,10 +2541,28 @@ class PhysicalDefectsPage(Adw.Bin):
             ):
                 continue
             codes.add(self._defect_code(defect_type))
-        codes = sorted(codes, key=self._code_sort_key)
+        return sorted(codes, key=self._code_sort_key)
+
+    def get_failure_reasons(self):
+        """Reported defects are summarized as just their data codes (e.g.
+        "PD01, PD05") rather than the full defect/location text -- that
+        detail already lives on the tracking sheet (see get_notes_entries);
+        this is just the compact Spec Complete screen summary."""
+        if self.has_defects is None:
+            return ["Physical defects check not completed"]
+        if not self.has_defects:
+            return []
+        if not self._defect_entries:
+            return ["Physical defects present"]
+        codes = self._failed_codes()
         if not codes:
             return ["Physical defects present"]
         return [", ".join(codes)]
+
+    def get_datacodes(self):
+        """See TogglePage.get_datacodes -- same Data Codes feed, computed
+        from _failed_codes() above."""
+        return self._failed_codes()
 
     def get_notes_entries(self):
         """All reported defects are concatenated onto a single line (rather

--- a/src/sortly_register.py
+++ b/src/sortly_register.py
@@ -21,6 +21,18 @@ from sortly import (
     sortly_error_message,
 )
 
+# Master switch for reporting each manual test page's data codes (e.g.
+# "KB02,SC08,UA02" -- see SpecCompleteV3._gather_datacodes) back to Sortly
+# as a follow-up update after the initial registration on this page. Off
+# for now so spec_v3 sends Sortly exactly the same fields spec.py does;
+# flip to True once Sortly has a "Data Codes" custom attribute ready to
+# receive it -- see report_datacodes() below.
+REPORT_DATACODES_TO_SORTLY = False
+
+# Must match the custom attribute's name on the Sortly item exactly --
+# update_item() silently skips any field name it doesn't recognize.
+SORTLY_DATACODES_FIELD = "Data Codes"
+
 
 class SortlyRegister(Adw.Bin):
     def __init__(self):
@@ -442,6 +454,46 @@ class SortlyRegister(Adw.Bin):
             self._set_status(f"Failed: {error}", error=True)
             self.register_button.set_sensitive(True)
             self.knumber_entry.set_sensitive(True)
+
+    def report_datacodes(self, datacodes):
+        """Push the machine's aggregated data-codes string to Sortly as a
+        follow-up update to the item registered on this page. Called from
+        SpecCompleteV3 once every manual test page has reported in --
+        those results don't exist yet when _do_register() runs at the
+        start of the wizard, so this fires later instead.
+
+        A no-op while REPORT_DATACODES_TO_SORTLY is False (see top of
+        file), and also if this page's own registration never succeeded
+        (no item to update) or produced no codes to report.
+        """
+        if not REPORT_DATACODES_TO_SORTLY:
+            return
+        if not datacodes or not self._existing_item:
+            return
+
+        try:
+            api_key = get_api_key()
+        except EnvironmentError as e:
+            print(f"Skipping data codes report: {e}")
+            return
+
+        item_id = self._existing_item["id"]
+        thread = threading.Thread(
+            target=self._report_datacodes_thread,
+            args=(api_key, item_id, datacodes),
+            daemon=True,
+        )
+        thread.start()
+
+    def _report_datacodes_thread(self, api_key, item_id, datacodes):
+        try:
+            success = update_item(
+                api_key, item_id, {SORTLY_DATACODES_FIELD: datacodes}
+            )
+            if not success:
+                print("Failed to report data codes to Sortly.")
+        except Exception as e:
+            print(f"Failed to report data codes to Sortly: {sortly_error_message(e)}")
 
     def _populate_system_info(self):
         if not self._system_info:

--- a/src/speccomplete_v3.py
+++ b/src/speccomplete_v3.py
@@ -186,6 +186,19 @@ class SpecCompleteV3(Adw.Bin):
         else:
             self._generate_tracking_sheet()
 
+    def _gather_datacodes(self):
+        """Every manual test page's failure data codes (e.g. "KB02",
+        "SC08"), concatenated across all pages into one comma-separated
+        string with no spaces (e.g. "KB02,SC08,UA02") -- the format fed to
+        SortlyRegister.report_datacodes(). Pages that passed, weren't
+        tested, or have no get_datacodes() (SpecInfo isn't a manual test
+        page) contribute nothing."""
+        codes = []
+        for page in self.manual_test_pages:
+            if hasattr(page, "get_datacodes"):
+                codes.extend(page.get_datacodes())
+        return ",".join(codes)
+
     def _generate_tracking_sheet(self):
         knumber = ""
         if self.sortly_register:
@@ -219,6 +232,9 @@ class SpecCompleteV3(Adw.Bin):
 
         if self.specinfo is not None:
             notes_entries.extend(self.specinfo.get_notes_entries())
+
+        if self.sortly_register:
+            self.sortly_register.report_datacodes(self._gather_datacodes())
 
         self.tracking_button.set_sensitive(False)
         if not knumber:

--- a/src/specinfo.py
+++ b/src/specinfo.py
@@ -482,6 +482,7 @@ class SpecInfo(Adw.Bin):
         if self._gathered.get("asset_info") and not self.asset_info_override:
             return False
         if BLOCK_NEXT_WHEN_DRIVE_PRESENT and self.has_disks and not self.disk_override:
+            # MAKE SURE THIS IS FALSE WHEN COMMITTING TO GIT
             return False
         return True
 


### PR DESCRIPTION
This pull request introduces several improvements and new features related to battery reporting, data code tracking, and user interface enhancements for the manual test and tracking sheet generation workflows. The main themes are more explicit handling of battery information, support for reporting detailed failure data codes to Sortly, and minor UI/UX improvements.

**Battery reporting improvements:**

* The battery display logic in both `generate_tracking_sheet.py` and `generate_tracking_sheet_v3.py` now always shows "Bat0" explicitly, even on machines with only a secondary battery or no batteries at all, preventing incorrect assignment of battery slots. The secondary battery ("Bat1") is shown only if present. [[1]](diffhunk://#diff-d2b36a68966ca0f9812a7531cfdbf5b760c627497f7c2cde0213da13b443d91aL369-R382) [[2]](diffhunk://#diff-b586b28816ef5efcfbfd2071a3f6027f3163359acad44b72ffef2fe25137304dL499-R512)
* The table layout for the spec grid adapts more robustly to the presence or absence of a second battery, using the new `bat1_value` logic.

**Data codes tracking and reporting:**

* Adds a mechanism to collect data codes (e.g., "KB02,SC08") from each manual test page, aggregate them in `SpecCompleteV3`, and (optionally) report them to Sortly as a custom field after registration. This is controlled by a master switch (`REPORT_DATACODES_TO_SORTLY`) and is currently off until Sortly is ready for the new field. [[1]](diffhunk://#diff-b18c7fe6bea5ae9284465b721964b01fa87c9a86229bec4e9cdf5a6db31b41abR1304-R1314) [[2]](diffhunk://#diff-b18c7fe6bea5ae9284465b721964b01fa87c9a86229bec4e9cdf5a6db31b41abR2547-R2585) [[3]](diffhunk://#diff-a64f64b4dcf556e7c479a6d7682597cf564f81f0890908d26aeb65063e2b1a80R24-R35) [[4]](diffhunk://#diff-a64f64b4dcf556e7c479a6d7682597cf564f81f0890908d26aeb65063e2b1a80R458-R497) [[5]](diffhunk://#diff-f5dec80ade4ca5fed3a6c4211a15a5158d8b34729bb4c3b3058c05911c51fb9cR189-R201) [[6]](diffhunk://#diff-f5dec80ade4ca5fed3a6c4211a15a5158d8b34729bb4c3b3058c05911c51fb9cR236-R238)

**Manual test UI/UX improvements:**

* Adds `_build_note_row()` for embedding informational notes in the UI, and uses it to remind users to check for a webcam privacy shutter when reporting "solid black screen" webcam failures. [[1]](diffhunk://#diff-b18c7fe6bea5ae9284465b721964b01fa87c9a86229bec4e9cdf5a6db31b41abR646-R664) [[2]](diffhunk://#diff-b18c7fe6bea5ae9284465b721964b01fa87c9a86229bec4e9cdf5a6db31b41abR3082-R3091)
* Updates USB-C test instructions to clarify that defective ports should be taped over and reported.
* Fixes a grammar issue in the keyboard test string.

**Miscellaneous:**

* Adds a warning comment in `specinfo.py` to ensure a debug override is not accidentally committed.