### PR TITLE
Spec v3 bug fixes

### DIFF
--- a/src/manualtest_v3.py
+++ b/src/manualtest_v3.py
@@ -2647,6 +2647,9 @@ class WiFiPage(TogglePage):
             state[self.key] = connected or bool(self.passed)
         print(f"WiFi:on_shown connected={connected} skip={self.skip}")
 
+    def build_reason_locations(self, entry_row, reason):
+        return {"type": "none"}
+
 
 class TouchpadPage(TogglePage):
     def __init__(self):

--- a/src/manualtest_v3.py
+++ b/src/manualtest_v3.py
@@ -28,9 +28,23 @@ PHYSICAL_DEFECT_TYPES = [
     "Peeling Paint",
     "Cracks",
     "Broken Part",
+    "Feet Coming Off/Missing From Device",
 ]
-# Hinge issues are self-explanatory with no meaningful location to ask for.
-PHYSICAL_NO_LOCATION_TYPES = {"Hinge Broken", "Loose Hinge"}
+# Fixed code overrides for defect types whose position in the list above
+# doesn't match their tracking-sheet code (see
+# PhysicalDefectsPage._defect_code) -- e.g. "Feet Coming Off/Missing From
+# Device" is PD08 by convention rather than the PD06 its list position
+# would otherwise imply, since PD06/PD07 are reserved.
+PHYSICAL_DEFECT_CODES = {
+    "Feet Coming Off/Missing From Device": "PD08",
+}
+# Hinge/feet issues are self-explanatory with no meaningful location to ask
+# for.
+PHYSICAL_NO_LOCATION_TYPES = {
+    "Hinge Broken",
+    "Loose Hinge",
+    "Feet Coming Off/Missing From Device",
+}
 # Marked the same way as a screen/touchscreen defect (see SCREEN_SECTIONS).
 PHYSICAL_SCREEN_SECTION_TYPES = {"Screen Cracked"}
 # Ask which part is affected, then where on that part (same sextant grid as
@@ -136,7 +150,20 @@ TOUCHPAD_DEFECT_TYPES = [
     "A problem with left or right click",
     "Touchpad looks as if it is bulging out",
     "Something is wrong with how the cursor moves",
+    "Part of the touchpad doesn't work",
 ]
+
+# "Part of the touchpad doesn't work" pops up the same 6-section grid used
+# for screen/touchscreen locations (see SCREEN_SECTIONS) so the tech can
+# mark which part is dead -- see TouchpadPage.build_reason_locations. It
+# gets a fixed TP09 code (see TOUCHPAD_REASON_CODES/TouchpadPage._reason_code)
+# rather than the position-based TP05 its slot in the list above would
+# otherwise imply, since TP05/TP06 are already taken by the cursor
+# sub-reasons (see TOUCHPAD_CURSOR_CODES).
+TOUCHPAD_PARTIAL_REASON = "Part of the touchpad doesn't work"
+TOUCHPAD_REASON_CODES = {
+    TOUCHPAD_PARTIAL_REASON: "TP09",
+}
 
 # "A problem with left or right click" expands into "Left click"/"Right
 # click"/"Touchpad click" instead of the generic touchpad-location section
@@ -191,6 +218,7 @@ TOUCHPAD_CURSOR_OPTIONS = list(TOUCHPAD_CURSOR_CODES)
 TOUCHPAD_REASON_NOTES = {
     "Touchpad does not work at all": "Touchpad broken",
     "Touchpad looks as if it is bulging out": "Touchpad bulging",
+    TOUCHPAD_PARTIAL_REASON: "Part of touchpad not working",
 }
 
 SCREEN_DEFECT_TYPES = [
@@ -2426,7 +2454,12 @@ class PhysicalDefectsPage(Adw.Bin):
             self.on_status_changed()
 
     def _defect_code(self, defect_type):
-        """See CUSTOM_REASON_CODE_SUFFIX near the top of this file."""
+        """See CUSTOM_REASON_CODE_SUFFIX near the top of this file. Most
+        codes are just the defect's 1-based position in
+        PHYSICAL_DEFECT_TYPES, but PHYSICAL_DEFECT_CODES overrides that for
+        defect types whose code doesn't match their list position."""
+        if defect_type in PHYSICAL_DEFECT_CODES:
+            return PHYSICAL_DEFECT_CODES[defect_type]
         try:
             return (
                 f"{self.CODE_PREFIX}{PHYSICAL_DEFECT_TYPES.index(defect_type) + 1:02d}"
@@ -2641,6 +2674,12 @@ class TouchpadPage(TogglePage):
                 options=TOUCHPAD_CURSOR_OPTIONS,
                 title="What's the cursor doing wrong?",
             )
+        if reason == TOUCHPAD_PARTIAL_REASON:
+            return _build_section_picker(
+                self,
+                entry_row,
+                title="Which part of the touchpad doesn't work?",
+            )
         # "Touchpad does not work at all" / "Touchpad feels very tight"
         # apply to the whole touchpad -- no location to narrow down. Any
         # custom free-text reason gets no location picker either, to keep
@@ -2753,11 +2792,16 @@ class TouchpadPage(TogglePage):
     def _reason_code(self, reason):
         """Overrides TogglePage._reason_code -- "A problem with left or
         right click" and "Something is wrong with how the cursor moves"
-        get no single code of their own (see class docstring above);
-        every other touchpad reason keeps the default position-based
-        code."""
+        get no single code of their own (see class docstring above).
+        "Part of the touchpad doesn't work" gets a fixed code from
+        TOUCHPAD_REASON_CODES rather than its position in
+        TOUCHPAD_DEFECT_TYPES, since TP04-TP08 are already spoken for by
+        the click/cursor sub-reasons. Every other touchpad reason keeps
+        the default position-based code."""
         if reason in (TOUCHPAD_CLICK_REASON, TOUCHPAD_CURSOR_REASON):
             return None
+        if reason in TOUCHPAD_REASON_CODES:
+            return TOUCHPAD_REASON_CODES[reason]
         return super()._reason_code(reason)
 
     def _touchpad_click_notes(self, data):
@@ -2803,6 +2847,11 @@ class TouchpadPage(TogglePage):
         if reason == TOUCHPAD_CURSOR_REASON:
             return self._touchpad_cursor_notes(data)
         code = self._reason_code(reason)
+        if reason == TOUCHPAD_PARTIAL_REASON:
+            loc_text = self._locations_text(data)
+            label = TOUCHPAD_REASON_NOTES[reason]
+            text = f"{code} {label}: {loc_text}" if loc_text else f"{code} {label}"
+            return [(code, text)]
         if reason in TOUCHPAD_REASON_NOTES:
             return [(code, f"{code} {TOUCHPAD_REASON_NOTES[reason]}")]
         # Custom free-text reason -- fall back to the generic coded label

--- a/src/meson.build
+++ b/src/meson.build
@@ -68,6 +68,7 @@ sources = [
   'observable.py',
   'osloadcomplete.py',
   'osload.py',
+  'screen_section_picker_runner.py',
   'sortly.py',
   'loading_capture.py',
   'sortly_register.py',

--- a/src/sortly_register.py
+++ b/src/sortly_register.py
@@ -242,7 +242,7 @@ class SortlyRegister(Adw.Bin):
             self._set_status("Invalid K-number format.", error=True)
             return
 
-        if not Utils.is_wifi_connected():
+        if not Utils.is_network_connected():
             self._show_wifi_warning()
             return
 
@@ -315,7 +315,7 @@ class SortlyRegister(Adw.Bin):
             self._set_status("Invalid K-number format.", error=True)
             return
 
-        if not Utils.is_wifi_connected():
+        if not Utils.is_network_connected():
             self._show_wifi_warning()
             return
 
@@ -486,8 +486,8 @@ class SortlyRegister(Adw.Bin):
             modal=True,
             message_type=Gtk.MessageType.WARNING,
             buttons=Gtk.ButtonsType.OK,
-            text="Not connected to WiFi",
-            secondary_text="This laptop isn't connected to WiFi, so Sortly can't be reached. Connect to a network and try again.",
+            text="Not connected to a network",
+            secondary_text="This laptop isn't connected to WiFi or Ethernet, so Sortly can't be reached. Connect to a network and try again.",
         )
         dialog.connect("response", lambda d, r: d.close())
         dialog.present()

--- a/src/utils.py
+++ b/src/utils.py
@@ -1016,6 +1016,30 @@ class Utils:
             return False
 
     @staticmethod
+    def is_network_connected():
+        """Whether any network device (WiFi or Ethernet) currently has an
+        active connection -- used to gate features that just need internet
+        access, where Ethernet should count just as much as WiFi."""
+        try:
+            result = subprocess.run(
+                ["nmcli", "-t", "-f", "TYPE,STATE", "device"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            for line in result.stdout.strip().splitlines():
+                parts = line.split(":")
+                if (
+                    len(parts) == 2
+                    and parts[0] in ("wifi", "ethernet")
+                    and parts[1] == "connected"
+                ):
+                    return True
+            return False
+        except Exception:
+            return False
+
+    @staticmethod
     def has_usb_c():
         """Whether this device exposes any USB-C (Type-C) ports, used to
         decide whether the USB-C manual test page should be shown at all.


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the defect tracking and network connectivity handling logic. The main changes include adding explicit code overrides for certain defect types, improving the handling and labeling of partial touchpad failures, and enhancing network connectivity checks to include both WiFi and Ethernet. Additionally, some UI messages have been updated for clarity.

**Defect code handling improvements:**

* Added `PHYSICAL_DEFECT_CODES` to override default defect codes for specific physical defect types (e.g., "Feet Coming Off/Missing From Device" now gets code "PD08" instead of a position-based code). The `_defect_code` method now checks this override. [[1]](diffhunk://#diff-b18c7fe6bea5ae9284465b721964b01fa87c9a86229bec4e9cdf5a6db31b41abR31-R47) [[2]](diffhunk://#diff-b18c7fe6bea5ae9284465b721964b01fa87c9a86229bec4e9cdf5a6db31b41abL2429-R2462)
* Updated `PHYSICAL_NO_LOCATION_TYPES` to include "Feet Coming Off/Missing From Device", ensuring no location is requested for this defect.

**Touchpad defect handling enhancements:**

* Introduced a fixed code ("TP09") and custom location picker for "Part of the touchpad doesn't work", ensuring it is tracked distinctly and consistently, with appropriate UI and reporting logic. [[1]](diffhunk://#diff-b18c7fe6bea5ae9284465b721964b01fa87c9a86229bec4e9cdf5a6db31b41abR153-R167) [[2]](diffhunk://#diff-b18c7fe6bea5ae9284465b721964b01fa87c9a86229bec4e9cdf5a6db31b41abR2680-R2685) [[3]](diffhunk://#diff-b18c7fe6bea5ae9284465b721964b01fa87c9a86229bec4e9cdf5a6db31b41abL2756-R2807) [[4]](diffhunk://#diff-b18c7fe6bea5ae9284465b721964b01fa87c9a86229bec4e9cdf5a6db31b41abR2853-R2857)
* Added a descriptive label for partial touchpad failures in `TOUCHPAD_REASON_NOTES`.

**Network connectivity improvements:**

* Added a new utility method `is_network_connected` to check for both WiFi and Ethernet connections, and updated Sortly registration logic to use this method instead of the WiFi-only check. [[1]](diffhunk://#diff-51246e53255db77c9edad496f074aa1bdbf8dbdc11f89a02040115c9ab4fa7f0R1018-R1041) [[2]](diffhunk://#diff-a64f64b4dcf556e7c479a6d7682597cf564f81f0890908d26aeb65063e2b1a80L245-R245) [[3]](diffhunk://#diff-a64f64b4dcf556e7c479a6d7682597cf564f81f0890908d26aeb65063e2b1a80L318-R318)
* Updated the network warning dialog to mention both WiFi and Ethernet for clarity.

**Build system update:**

* Added `screen_section_picker_runner.py` to the Meson build sources.