### PR TITLE
Spec v3 bug fixes

### DIFF
--- a/src/generate_tracking_sheet_v3.py
+++ b/src/generate_tracking_sheet_v3.py
@@ -683,9 +683,10 @@ def generate_tracking_sheet(
     def usb_result_cell():
         """USB-A and USB-C are separate manual test pages (see
         manualtest_v3.UsbAPage/UsbCPage) but share one "USB:" cell here.
-        "USBC" is only present in manual_test_results on devices with a
-        USB-C port (see spec_v3.py's has_usb_c() gating), mirroring the
-        Touchscreen key's presence-means-applicable convention above."""
+        "USBC" is only present in manual_test_results on devices where the
+        USB-C page was shown (see spec_v3.py's Utils.should_show_usb_c_page()
+        gating), mirroring the Touchscreen key's presence-means-applicable
+        convention above."""
         segments = [("A", test_value("USBA"))]
         if "USBC" in mt:
             segments.append(("C", test_value("USBC")))

--- a/src/manualtest_v3.py
+++ b/src/manualtest_v3.py
@@ -977,7 +977,11 @@ class TogglePage(Adw.Bin):
         vbox.set_valign(Gtk.Align.START)
 
         self.scrolled = Gtk.ScrolledWindow()
-        self.scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        # Horizontal scrolling (rather than NEVER) keeps any unexpectedly
+        # wide content -- e.g. a long button grid -- from forcing the whole
+        # window wider than the screen; it scrolls instead of pushing the
+        # window's minimum size out.
+        self.scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         self.scrolled.set_vexpand(True)
         self.scrolled.set_hexpand(True)
         self.scrolled.set_child(vbox)
@@ -1466,7 +1470,11 @@ class PhysicalDefectsPage(Adw.Bin):
         vbox.set_valign(Gtk.Align.START)
 
         self.scrolled = Gtk.ScrolledWindow()
-        self.scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        # Horizontal scrolling (rather than NEVER) keeps any unexpectedly
+        # wide content -- e.g. a long button grid -- from forcing the whole
+        # window wider than the screen; it scrolls instead of pushing the
+        # window's minimum size out.
+        self.scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         self.scrolled.set_vexpand(True)
         self.scrolled.set_hexpand(True)
         self.scrolled.set_child(vbox)
@@ -1638,7 +1646,7 @@ class PhysicalDefectsPage(Adw.Bin):
         parts_row = _build_section_row(
             f"Where is/are the {entry_row.get_title()}(s)?",
             PHYSICAL_AFFECTED_PARTS,
-            columns=len(PHYSICAL_AFFECTED_PARTS),
+            columns=3,
             on_change=_on_parts_change,
         )
         entry_row.add_row(parts_row)

--- a/src/manualtest_v3.py
+++ b/src/manualtest_v3.py
@@ -119,7 +119,7 @@ USB_C_DEFECT_TYPES = [
     "USB-C Port is finicky, connection cuts in and out",
     "USB-C Port does not work",
     "USB-C Port is physically damage",
-    "USB-C Port works one way, but when flipping it upside-down, it doesn't work",
+    "USB-C Port only works one way",
 ]
 # Must match an entry in USB_C_DEFECT_TYPES exactly -- see
 # USB_A_PORT_DAMAGE_REASON above, same suppression but for UsbCPage.
@@ -130,7 +130,7 @@ USB_C_REASON_CODES = {
     "USB-C Port is finicky, connection cuts in and out": "UC01",
     "USB-C Port does not work": "UC01",
     "USB-C Port is physically damage": "UC02",
-    "USB-C Port works one way, but when flipping it upside-down, it doesn't work": "UC03",
+    "USB-C Port only works one way": "UC03",
 }
 
 USB_PORT_LOCATIONS = ["Left Side", "Right Side", "Back"]
@@ -242,9 +242,9 @@ SCREEN_BROKEN_REASON = "Screen broken"
 WEBCAM_DEFECT_TYPES = [
     "The webcam does not work at all",
     "The webcam reports a solid black screen",
-    "There are lines going across or down the webcam output",
+    "Lines going across or down webcam output",
     "The Image is blurry",
-    "The video is very choppy with a low frame rate",
+    "The video is choppy with low frame rate",
     "Everything is monochrome and flashing",
     "No webcam device found",
 ]

--- a/src/manualtest_v3.py
+++ b/src/manualtest_v3.py
@@ -3247,9 +3247,8 @@ class UsbCPage(UsbPortLocationMixin, TogglePage):
             instructions=(
                 "Use a provided USB-C dock and USB mouse to test each USB-C "
                 "port. Also, plug into each USB-C port upside-down and test "
-                "it that way as well. If the only USB-C port present is the "
-                "charging port, then you may select yes and move on. Place tape "
-                "over any defective USB-C ports and report it below."
+                "it that way as well. Place tape over any defective USB-C "
+                "ports and report it below."
             ),
         )
 

--- a/src/spec_v3.py
+++ b/src/spec_v3.py
@@ -63,8 +63,8 @@ class WizardWindow(Gtk.ApplicationWindow):
         has_touchscreen = Utils.has_touchscreen()
         if has_touchscreen:
             initial_state["Touchscreen"] = False
-        has_usb_c = Utils.has_usb_c()
-        if has_usb_c:
+        show_usb_c_page = Utils.should_show_usb_c_page()
+        if show_usb_c_page:
             initial_state["USBC"] = False
         self.observable_property = ObservableProperty(initial_state)
         # Create and add an observer
@@ -110,7 +110,7 @@ class WizardWindow(Gtk.ApplicationWindow):
         browser = BrowserPage()
         webcam = WebcamPage()
         usb_a = UsbAPage()
-        usb_c_pages = [UsbCPage()] if has_usb_c else []
+        usb_c_pages = [UsbCPage()] if show_usb_c_page else []
         physical_defects.usb_a_page = usb_a
         physical_defects.usb_c_page = usb_c_pages[0] if usb_c_pages else None
         physical_defects.keyboard_page = keyboard

--- a/src/spec_v3.py
+++ b/src/spec_v3.py
@@ -32,7 +32,7 @@ class WizardWindow(Gtk.ApplicationWindow):
         super().__init__(application=app, title="Kramden - Spec (v3)")
 
         self.set_icon_name("kramden")
-        self.set_default_size(800, 800)
+        self.set_default_size(1000, 900)
         self._monitors_model = None
         self._monitor_signal_handler = None
         display = Gdk.Display.get_default()
@@ -181,8 +181,8 @@ class WizardWindow(Gtk.ApplicationWindow):
     def _apply_monitor_size(self, monitor):
         geo = monitor.get_geometry()
         self.set_default_size(
-            min(800, int(geo.width * 0.8)),
-            min(800, int(geo.height * 0.8)),
+            min(1000, int(geo.width * 0.8)),
+            min(900, int(geo.height * 0.8)),
         )
 
     def _on_monitors_changed(self, monitors, position, removed, added):

--- a/src/speccomplete_v3.py
+++ b/src/speccomplete_v3.py
@@ -125,6 +125,11 @@ class SpecCompleteV3(Adw.Bin):
         self._tracking_output_path = None
         self._tracking_ready_to_print = False
         self._tracking_initials = ""
+        # Set once the tech has clicked "Print Tracking Sheet" at least
+        # once, so a subsequent click (e.g. because the sheet hasn't come
+        # out yet) prompts for confirmation instead of silently queuing
+        # another print job -- see _on_tracking_clicked().
+        self._tracking_print_requested = False
         # Both must happen at least once (in order) before is_complete()
         # allows the wizard's "Complete" button to be clicked -- see
         # is_complete() and on_shown() below.
@@ -183,9 +188,42 @@ class SpecCompleteV3(Adw.Bin):
 
     def _on_tracking_clicked(self, button):
         if self._tracking_ready_to_print:
-            self._print_tracking_sheet()
+            if self._tracking_print_requested:
+                self._prompt_reprint_confirmation()
+            else:
+                self._print_tracking_sheet()
         else:
             self._prompt_for_initials()
+
+    def _prompt_reprint_confirmation(self):
+        dialog = Adw.MessageDialog(
+            transient_for=self.get_root(),
+            heading="Print Again?",
+            body=(
+                "Please wait up to 10 seconds for the tracking sheet to "
+                "print before trying again. If you are sure you want to "
+                "print again, click the button below.\n\n"
+                "If the printer is not receiving your print request, "
+                "please take a mental note of any failures, or write a "
+                "note so you don't forget, and restart the laptop. Fill "
+                "out all of the manual test pages just like before, and "
+                "retry printing. If it still doesn't work, find a Super "
+                "Geek or Staff Member to help you."
+            ),
+        )
+        dialog.add_response("cancel", "Cancel")
+        dialog.add_response("print_again", "Print Again")
+        dialog.set_response_appearance(
+            "print_again", Adw.ResponseAppearance.SUGGESTED
+        )
+        dialog.set_default_response("cancel")
+        dialog.set_close_response("cancel")
+        dialog.connect("response", self._on_reprint_confirmation_response)
+        dialog.present()
+
+    def _on_reprint_confirmation_response(self, dialog, response):
+        if response == "print_again":
+            self._print_tracking_sheet()
 
     def _prompt_for_initials(self):
         dialog = Adw.MessageDialog(
@@ -218,10 +256,16 @@ class SpecCompleteV3(Adw.Bin):
         )
 
         dialog.connect("response", self._on_initials_response, entry)
+        # Without this, keyboard focus stays on the "Review Tracking Sheet"
+        # button that was just clicked to open this dialog, so pressing
+        # Enter re-triggers that button instead of submitting the initials.
+        self.tracking_button.set_sensitive(False)
         dialog.present()
+        entry.grab_focus()
 
     def _on_initials_response(self, dialog, response, entry):
         if response != "continue":
+            self.tracking_button.set_sensitive(True)
             return
         self._tracking_initials = entry.get_text().strip()
         self._generate_tracking_sheet()
@@ -489,6 +533,7 @@ class SpecCompleteV3(Adw.Bin):
         if not output_path:
             return
 
+        self._tracking_print_requested = True
         self.tracking_button.set_sensitive(False)
         self.tracking_status.set_label("Printing...")
         if self.tracking_status.has_css_class("text-error"):
@@ -568,6 +613,7 @@ class SpecCompleteV3(Adw.Bin):
         self._tracking_ready_to_print = False
         self._tracking_reviewed = False
         self._tracking_printed = False
+        self._tracking_print_requested = False
         self._tracking_initials = ""
         self.tracking_button.set_label("Review Tracking Sheet")
         self.tracking_button.remove_css_class("button-green")

--- a/src/utils.py
+++ b/src/utils.py
@@ -1040,22 +1040,78 @@ class Utils:
             return False
 
     @staticmethod
+    def _typec_port_names():
+        """Names of actual Type-C port entries under /sys/class/typec/ (e.g.
+        "port0", "port1") -- excludes the "portN-partner"/"portN-cable"/
+        "portN-plugN" entries the kernel adds alongside a port once
+        something is attached to it, which aren't ports themselves and would
+        otherwise inflate a naive substring-match count.
+
+        Raises OSError if /sys/class/typec/ can't be listed at all (missing
+        directory, permissions, or a kernel/live-image with no typec driver
+        loaded for this hardware)."""
+        entries = os.listdir("/sys/class/typec/")
+        return [e for e in entries if re.fullmatch(r"port\d+", e)]
+
+    @staticmethod
+    def usb_c_port_count():
+        """Number of physical Type-C ports reported by the kernel, or 0 if
+        that can't be determined (see _typec_port_names)."""
+        try:
+            return len(Utils._typec_port_names())
+        except OSError as e:
+            print(f"usb_c_port_count: error reading /sys/class/typec/: {e}")
+            return 0
+
+    @staticmethod
+    def _has_usb_pd_power_supply():
+        """Whether any /sys/class/power_supply/ entry advertises USB Power
+        Delivery / Type-C support via its "usb_type" attribute (e.g.
+        "[C] PD PD_PPS"). Some Type-C charging paths (notably UCSI-based
+        ones) show up here even when no /sys/class/typec/ port ever
+        registers, so this is used as a fallback signal when the typec
+        class can't be read at all."""
+        try:
+            entries = os.listdir("/sys/class/power_supply/")
+        except OSError:
+            return False
+        pd_tokens = {"C", "PD", "PD_DRP", "PD_PPS"}
+        for entry in entries:
+            try:
+                with open(f"/sys/class/power_supply/{entry}/usb_type", "r") as f:
+                    tokens = f.read().strip().replace("[", " ").replace("]", " ").split()
+            except OSError:
+                continue
+            if pd_tokens.intersection(tokens):
+                return True
+        return False
+
+    @staticmethod
     def has_usb_c():
         """Whether this device exposes any USB-C (Type-C) ports, used to
         decide whether the USB-C manual test page should be shown at all.
 
         /sys/class/typec/ has one entry per Type-C port (e.g. "port0") when
-        the kernel's typec class is populated. If it can't be read at all
-        (missing directory, permissions, older kernel without the typec
-        class), fail open and show the page rather than silently skipping a
-        real port.
+        the kernel's typec class is populated, which is the authoritative
+        signal when it's readable at all -- including when it's readable
+        and empty (a real "no ports" answer, not a failure).
+
+        When it can't be read at all (missing directory, permissions, or a
+        kernel/live-image with no typec driver loaded), there is no sysfs
+        signal that proves the device truly has zero Type-C ports -- that
+        state is indistinguishable from "has USB-C but undetected by this
+        kernel". In practice, though, it overwhelmingly means "no USB-C
+        hardware", so treat it as such rather than failing open, and only
+        fall back to showing the page if a power supply separately reports
+        USB-PD/Type-C charging capability (see _has_usb_pd_power_supply),
+        which can appear even without a registered typec port.
         """
         try:
-            entries = os.listdir("/sys/class/typec/")
+            port_names = Utils._typec_port_names()
         except OSError as e:
             print(f"has_usb_c: error reading /sys/class/typec/: {e}")
-            return True
-        return any("port" in entry for entry in entries)
+            return Utils._has_usb_pd_power_supply()
+        return len(port_names) > 0
 
     @staticmethod
     def get_charging_port_status():
@@ -1159,6 +1215,33 @@ class Utils:
                 continue
 
         return primary_read_succeeded
+
+    @staticmethod
+    def should_show_usb_c_page():
+        """Whether the USB-C manual test page should be shown at all.
+
+        A device with no USB-C ports never shows it. A device with USB-C
+        ports that also has a separate primary (Mains/barrel) charging port
+        always shows it, since the USB-C port(s) aren't otherwise exercised
+        during provisioning. A device with two or more USB-C ports also
+        always shows it, since even without a separate primary port, having
+        several means at least one of them isn't required for charging and
+        could be silently broken.
+
+        The one case it's skipped: exactly one USB-C port, and it's the
+        device's only charging port (no primary port, and a secondary USB
+        charging path is confirmed present) -- that port is already
+        exercised just by powering the device on for provisioning, so
+        there's nothing left to manually verify.
+        """
+        if not Utils.has_usb_c():
+            return False
+        if Utils.usb_c_port_count() != 1:
+            return True
+        status = Utils.get_charging_port_status()
+        if status["has_primary_port"] or not status["has_secondary_port"]:
+            return True
+        return False
 
     KRAMDEN_EFIVAR_GUID = "9a8e2042-75d4-4d70-9890-6a8437367c1f"
     KRAMDEN_EFIVAR_PATH = (


### PR DESCRIPTION
This pull request introduces several improvements and refinements to the USB-C detection logic, the user interface for manual testing, and the tracking sheet printing workflow. The most significant changes are the overhaul of USB-C port detection and gating logic, improved tracking sheet print confirmation, and various UI/UX enhancements.

**USB-C detection and gating improvements:**

* Refactored USB-C port detection in `Utils.has_usb_c()` to use a more robust method that counts only true Type-C ports and falls back to power supply signals if `/sys/class/typec/` is unavailable, reducing false positives and negatives.
* Added `Utils.usb_c_port_count()` and `Utils.should_show_usb_c_page()` to determine when the USB-C manual test page should be shown, skipping it for devices with only one USB-C port used solely for charging.
* Updated `spec_v3.py` to use `Utils.should_show_usb_c_page()` instead of `Utils.has_usb_c()` for gating the USB-C test page and related state, ensuring correct behavior across hardware variations. [[1]](diffhunk://#diff-a0fa340a34dcc18dbba451db0ab136c2841d8d2b153b2a06d315fe063b392e7cL66-R67) [[2]](diffhunk://#diff-a0fa340a34dcc18dbba451db0ab136c2841d8d2b153b2a06d315fe063b392e7cL113-R113)
* Clarified comments and docstrings throughout the codebase to document the new USB-C gating logic and its rationale.

**Tracking sheet printing workflow enhancements:**

* Added a confirmation dialog before reprinting the tracking sheet to prevent accidental duplicate print jobs and provide user guidance if printing fails.
* Improved tracking sheet dialog focus handling, disabling the print button during input and restoring it on cancellation, for a smoother user experience.
* Added a flag to track print requests and reset it appropriately when the completion page is shown or printing is triggered. [[1]](diffhunk://#diff-f5dec80ade4ca5fed3a6c4211a15a5158d8b34729bb4c3b3058c05911c51fb9cR128-R132) [[2]](diffhunk://#diff-f5dec80ade4ca5fed3a6c4211a15a5158d8b34729bb4c3b3058c05911c51fb9cR536) [[3]](diffhunk://#diff-f5dec80ade4ca5fed3a6c4211a15a5158d8b34729bb4c3b3058c05911c51fb9cR616)

**UI/UX improvements:**

* Increased the default and minimum window sizes in `spec_v3.py` for better usability on larger screens. [[1]](diffhunk://#diff-a0fa340a34dcc18dbba451db0ab136c2841d8d2b153b2a06d315fe063b392e7cL35-R35) [[2]](diffhunk://#diff-a0fa340a34dcc18dbba451db0ab136c2841d8d2b153b2a06d315fe063b392e7cL184-R185)
* Changed `Gtk.ScrolledWindow` policies to allow horizontal scrolling, preventing overly wide content from expanding the window beyond the screen. [[1]](diffhunk://#diff-b18c7fe6bea5ae9284465b721964b01fa87c9a86229bec4e9cdf5a6db31b41abL1001-R1005) [[2]](diffhunk://#diff-b18c7fe6bea5ae9284465b721964b01fa87c9a86229bec4e9cdf5a6db31b41abL1501-R1509)
* Limited the number of columns in the affected parts selector to 3 for improved layout consistency.

**Defect type and instruction text refinements:**

* Updated USB-C and webcam defect type strings for clarity and brevity, and revised USB-C test instructions to remove outdated references to charging port exceptions. [[1]](diffhunk://#diff-b18c7fe6bea5ae9284465b721964b01fa87c9a86229bec4e9cdf5a6db31b41abL122-R122) [[2]](diffhunk://#diff-b18c7fe6bea5ae9284465b721964b01fa87c9a86229bec4e9cdf5a6db31b41abL133-R133) [[3]](diffhunk://#diff-b18c7fe6bea5ae9284465b721964b01fa87c9a86229bec4e9cdf5a6db31b41abL245-R247) [[4]](diffhunk://#diff-b18c7fe6bea5ae9284465b721964b01fa87c9a86229bec4e9cdf5a6db31b41abL3242-R3251)

These changes collectively improve hardware detection reliability, user experience, and the clarity of instructions and defect reporting.